### PR TITLE
feat: redesign launcher UI and harden runtime controls

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -90,3 +90,8 @@ pub async fn check_tcp_connection(host: String, port: u16) -> Result<bool> {
 
     Ok(result)
 }
+
+#[tauri::command]
+pub async fn is_rustfs_process_running() -> Result<bool> {
+    Ok(state::is_rustfs_process_running())
+}

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -8,6 +8,8 @@ pub struct RustFsConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub console_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub host: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub access_key: Option<String>,
@@ -22,6 +24,7 @@ impl Default for RustFsConfig {
             binary_path: None,
             data_path: String::new(),
             port: Some(9000),
+            console_port: Some(9001),
             host: Some("127.0.0.1".to_string()),
             access_key: Some("rustfsadmin".to_string()),
             secret_key: Some("rustfsadmin".to_string()),

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -11,6 +11,9 @@ pub enum Error {
     #[error("Data path does not exist: {0}")]
     DataPathNotExist(String),
 
+    #[error("API port and console port must be different")]
+    PortConflict,
+
     #[error("RustFS binary not found at {0}")]
     BinaryNotFound(String),
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,7 +100,8 @@ pub fn run() {
             commands::get_app_logs,
             commands::get_rustfs_logs,
             commands::diagnose_rustfs_binary,
-            commands::check_tcp_connection
+            commands::check_tcp_connection,
+            commands::is_rustfs_process_running
         ])
         .build(tauri::generate_context!())
         .expect("error building tauri application")

--- a/src-tauri/src/process.rs
+++ b/src-tauri/src/process.rs
@@ -170,6 +170,13 @@ pub fn launch(config: RustFsConfig) -> Result<String> {
         return Err(Error::DataPathRequired);
     }
 
+    let api_port = config.port.unwrap_or(9000);
+    let console_port = config.console_port.unwrap_or(9001);
+
+    if config.console_enable && api_port == console_port {
+        return Err(Error::PortConflict);
+    }
+
     let binary_path = match &config.binary_path {
         Some(path) => PathBuf::from(path),
         None => get_binary_path()?,
@@ -199,9 +206,15 @@ pub fn launch(config: RustFsConfig) -> Result<String> {
     let address = format!(
         "{}:{}",
         config.host.as_deref().unwrap_or("127.0.0.1"),
-        config.port.unwrap_or(9000)
+        api_port
     );
     cmd.arg("--address").arg(&address);
+
+    let console_address = format!(
+        "{}:{}",
+        config.host.as_deref().unwrap_or("127.0.0.1"),
+        console_port
+    );
 
     if let Some(access_key) = &config.access_key {
         cmd.arg("--access-key").arg(access_key);
@@ -211,6 +224,7 @@ pub fn launch(config: RustFsConfig) -> Result<String> {
     }
     if config.console_enable {
         cmd.arg("--console-enable");
+        cmd.arg("--console-address").arg(&console_address);
     }
 
     #[cfg(windows)]
@@ -220,7 +234,15 @@ pub fn launch(config: RustFsConfig) -> Result<String> {
         cmd.creation_flags(CREATE_NO_WINDOW);
     }
 
-    add_app_log(format!("Spawning command: {:?}", cmd));
+    add_app_log(format!(
+        "Spawning RustFS: binary={}, address={}, console_enable={}, console_address={}, access_key_set={}, secret_key_set={}",
+        binary_path.display(),
+        address,
+        config.console_enable,
+        console_address,
+        config.access_key.is_some(),
+        config.secret_key.is_some()
+    ));
     let mut child = cmd
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -15,14 +15,34 @@ lazy_static! {
 
 lazy_static! {
     static ref ANSI_REGEX: Regex = Regex::new(r"\x1B\[[0-9;]*m").unwrap();
+    static ref SECRET_PATTERNS: Vec<Regex> = vec![
+        Regex::new(r#"(--access-key\s+)(\S+)"#).unwrap(),
+        Regex::new(r#"(--secret-key\s+)(\S+)"#).unwrap(),
+        Regex::new(r#"(access_key\s*=\s*)([^,\s]+)"#).unwrap(),
+        Regex::new(r#"(secret_key\s*=\s*)([^,\s]+)"#).unwrap(),
+        Regex::new(r#"(access_key:\s*Some\(")([^"]+)("\))"#).unwrap(),
+        Regex::new(r#"(secret_key:\s*Some\(")([^"]+)("\))"#).unwrap(),
+        Regex::new(r#"("access_key"\s*:\s*")([^"]+)(")"#).unwrap(),
+        Regex::new(r#"("secret_key"\s*:\s*")([^"]+)(")"#).unwrap(),
+    ];
 }
 
 fn clean_ansi_codes(s: &str) -> String {
     ANSI_REGEX.replace_all(s, "").to_string()
 }
 
+fn redact_secrets(s: &str) -> String {
+    SECRET_PATTERNS.iter().fold(s.to_string(), |acc, regex| {
+        regex.replace_all(&acc, "${1}[REDACTED]${3}").to_string()
+    })
+}
+
+fn clean_log_message(s: &str) -> String {
+    redact_secrets(&clean_ansi_codes(s))
+}
+
 fn buffer_log(logs: &Arc<Mutex<VecDeque<String>>>, message: String, capacity: usize) -> String {
-    let cleaned_message = clean_ansi_codes(&message);
+    let cleaned_message = clean_log_message(&message);
     let log_entry = format!(
         "[{}] {}",
         chrono::Local::now().format("%H:%M:%S"),
@@ -73,6 +93,26 @@ pub fn get_app_logs() -> Vec<String> {
 
 pub fn get_rustfs_logs() -> Vec<String> {
     RUSTFS_LOGS.lock().unwrap().iter().cloned().collect()
+}
+
+pub fn is_rustfs_process_running() -> bool {
+    let mut process_guard = RUSTFS_PROCESS.lock().unwrap();
+
+    match process_guard.as_mut() {
+        Some(child) => match child.try_wait() {
+            Ok(None) => true,
+            Ok(Some(_)) => {
+                *process_guard = None;
+                false
+            }
+            Err(e) => {
+                add_app_log(format!("Failed to inspect RustFS process status: {}", e));
+                *process_guard = None;
+                false
+            }
+        },
+        None => false,
+    }
 }
 
 pub fn set_rustfs_process(process: Child) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,11 @@
 use crate::components::config_form::ConfigForm;
 use crate::components::log_viewer::LogViewer;
 use crate::components::toast::{Toast, ToastMessage, ToastType};
-use crate::types::{CommandResponse, LogType, RustFsConfig};
+use crate::types::{CommandResponse, LogEntry, LogType, RustFsConfig};
 use leptos::ev::SubmitEvent;
 use leptos::prelude::*;
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
@@ -26,12 +27,46 @@ fn is_tauri() -> bool {
         .unwrap_or(false)
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PersistedConfig {
+    data_path: String,
+    port: Option<u16>,
+    console_port: Option<u16>,
+    host: Option<String>,
+    console_enable: bool,
+}
+
+impl From<&RustFsConfig> for PersistedConfig {
+    fn from(config: &RustFsConfig) -> Self {
+        Self {
+            data_path: config.data_path.clone(),
+            port: config.port,
+            console_port: config.console_port,
+            host: config.host.clone(),
+            console_enable: config.console_enable,
+        }
+    }
+}
+
+impl From<PersistedConfig> for RustFsConfig {
+    fn from(config: PersistedConfig) -> Self {
+        RustFsConfig {
+            data_path: config.data_path,
+            port: config.port,
+            console_port: config.console_port,
+            host: config.host,
+            console_enable: config.console_enable,
+            ..RustFsConfig::default()
+        }
+    }
+}
+
 fn load_config() -> RustFsConfig {
     if let Some(window) = web_sys::window() {
         if let Ok(Some(storage)) = window.local_storage() {
             if let Ok(Some(json)) = storage.get_item("rustfs_config") {
-                if let Ok(config) = serde_json::from_str(&json) {
-                    return config;
+                if let Ok(config) = serde_json::from_str::<PersistedConfig>(&json) {
+                    return config.into();
                 }
             }
         }
@@ -42,22 +77,86 @@ fn load_config() -> RustFsConfig {
 fn save_config(config: &RustFsConfig) {
     if let Some(window) = web_sys::window() {
         if let Ok(Some(storage)) = window.local_storage() {
-            if let Ok(json) = serde_json::to_string(config) {
+            if let Ok(json) = serde_json::to_string(&PersistedConfig::from(config)) {
                 let _ = storage.set_item("rustfs_config", &json);
             }
         }
     }
 }
 
+fn describe_config(config: &RustFsConfig) -> String {
+    format!(
+        "data_path={}, host={:?}, port={:?}, console_enable={}, access_key_set={}, secret_key_set={}",
+        config.data_path,
+        config.host,
+        config.port,
+        config.console_enable,
+        config.access_key.is_some(),
+        config.secret_key.is_some()
+    )
+}
+
 const APP_LOG_CAPACITY: usize = 100;
 const RUSTFS_LOG_CAPACITY: usize = 1000;
+const DEFAULT_RUSTFS_PORT: u16 = 9000;
+const DEFAULT_CONSOLE_PORT: u16 = 9001;
+static NEXT_LOG_ID: AtomicU64 = AtomicU64::new(1);
 
-fn push_log(writer: WriteSignal<VecDeque<String>>, msg: String, capacity: usize) {
+fn next_log_id() -> u64 {
+    NEXT_LOG_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+fn to_log_entry(message: String) -> LogEntry {
+    LogEntry {
+        id: next_log_id(),
+        message,
+    }
+}
+
+fn push_log(writer: WriteSignal<VecDeque<LogEntry>>, msg: String, capacity: usize) {
     writer.update(|logs| {
-        logs.push_back(msg);
+        logs.push_back(to_log_entry(msg));
         if logs.len() > capacity {
             logs.pop_front();
         }
+    });
+}
+
+fn sync_runtime_status(
+    config: ReadSignal<RustFsConfig>,
+    set_is_running: WriteSignal<bool>,
+    set_can_stop: WriteSignal<bool>,
+    set_service_status: WriteSignal<bool>,
+) {
+    spawn_local(async move {
+        if !is_tauri() {
+            set_is_running.set(false);
+            set_can_stop.set(false);
+            set_service_status.set(false);
+            return;
+        }
+
+        let current = config.get_untracked();
+        let host = current.host.unwrap_or_else(|| "127.0.0.1".to_string());
+        let port = current.port.unwrap_or(DEFAULT_RUSTFS_PORT);
+
+        let tcp_args = js_sys::Object::new();
+        js_sys::Reflect::set(&tcp_args, &"host".into(), &host.into()).unwrap();
+        js_sys::Reflect::set(&tcp_args, &"port".into(), &port.into()).unwrap();
+
+        let service_online = tauri_invoke("check_tcp_connection", tcp_args.into())
+            .await
+            .as_bool()
+            .unwrap_or(false);
+        let managed_running =
+            tauri_invoke("is_rustfs_process_running", js_sys::Object::new().into())
+                .await
+                .as_bool()
+                .unwrap_or(false);
+
+        set_service_status.set(service_online);
+        set_can_stop.set(managed_running);
+        set_is_running.set(managed_running || service_online);
     });
 }
 
@@ -71,10 +170,11 @@ pub fn App() -> impl IntoView {
 
     let (toasts, set_toasts) = signal(Vec::<ToastMessage>::new());
     let (is_running, set_is_running) = signal(false);
-    let (app_logs, set_app_logs) = signal(VecDeque::<String>::new());
-    let (rustfs_logs, set_rustfs_logs) = signal(VecDeque::<String>::new());
+    let (app_logs, set_app_logs) = signal(VecDeque::<LogEntry>::new());
+    let (rustfs_logs, set_rustfs_logs) = signal(VecDeque::<LogEntry>::new());
     let (current_log_type, set_current_log_type) = signal(LogType::App);
     let (service_status, set_service_status) = signal(false);
+    let (can_stop, set_can_stop) = signal(false);
 
     let remove_toast = Callback::new(move |id: u64| {
         set_toasts.update(|current| {
@@ -106,41 +206,24 @@ pub fn App() -> impl IntoView {
 
     // Health Check Polling
     Effect::new(move |_| {
-        spawn_local(async move {
-            if !is_tauri() {
-                return;
-            }
+        if !is_tauri() {
+            return;
+        }
 
-            let closure = Closure::wrap(Box::new(move || {
-                spawn_local(async move {
-                    let current = config.get_untracked();
-                    if let Some(port) = current.port {
-                        let host = current.host.unwrap_or_else(|| "127.0.0.1".to_string());
+        sync_runtime_status(config, set_is_running, set_can_stop, set_service_status);
 
-                        let args = js_sys::Object::new();
-                        js_sys::Reflect::set(&args, &"host".into(), &host.into()).unwrap();
-                        js_sys::Reflect::set(&args, &"port".into(), &port.into()).unwrap();
+        let closure = Closure::wrap(Box::new(move || {
+            sync_runtime_status(config, set_is_running, set_can_stop, set_service_status);
+        }) as Box<dyn FnMut()>);
 
-                        match tauri_invoke("check_tcp_connection", args.into())
-                            .await
-                            .as_bool()
-                        {
-                            Some(is_active) => set_service_status.set(is_active),
-                            None => set_service_status.set(false),
-                        }
-                    }
-                });
-            }) as Box<dyn FnMut()>);
+        let _ = web_sys::window()
+            .unwrap()
+            .set_interval_with_callback_and_timeout_and_arguments_0(
+                closure.as_ref().unchecked_ref(),
+                3000, // 3 seconds
+            );
 
-            let _ = web_sys::window()
-                .unwrap()
-                .set_interval_with_callback_and_timeout_and_arguments_0(
-                    closure.as_ref().unchecked_ref(),
-                    3000, // 3 seconds
-                );
-
-            closure.forget(); // Leak the closure to keep it alive
-        });
+        closure.forget(); // Leak the closure to keep it alive
     });
 
     let app_log_writer = set_app_logs;
@@ -167,7 +250,7 @@ pub fn App() -> impl IntoView {
         const RUSTFS_EXIT_EVENT: &str = "rustfs-exit";
 
         fn create_log_listener(
-            logs_signal: WriteSignal<VecDeque<String>>,
+            logs_signal: WriteSignal<VecDeque<LogEntry>>,
             max_logs: usize,
         ) -> Closure<dyn FnMut(JsValue)> {
             Closure::wrap(Box::new(move |event: JsValue| {
@@ -183,6 +266,7 @@ pub fn App() -> impl IntoView {
             if let Ok(payload) = js_sys::Reflect::get(&event, &"payload".into()) {
                 if let Some(exit_code) = payload.as_string() {
                     set_is_running.set(false);
+                    set_can_stop.set(false);
                     set_service_status.set(false);
                     show_toast(
                         format!("RustFS exited with code: {}", exit_code),
@@ -238,21 +322,22 @@ pub fn App() -> impl IntoView {
         // Fetch initial logs
         let app_logs_value = tauri_invoke("get_app_logs", js_sys::Object::new().into()).await;
         if let Ok(logs_vec) = serde_wasm_bindgen::from_value::<Vec<String>>(app_logs_value) {
-            app_log_writer.set(logs_vec.into_iter().collect());
+            app_log_writer.set(logs_vec.into_iter().map(to_log_entry).collect());
         }
 
         let rustfs_logs_value = tauri_invoke("get_rustfs_logs", js_sys::Object::new().into()).await;
         if let Ok(logs_vec) = serde_wasm_bindgen::from_value::<Vec<String>>(rustfs_logs_value) {
-            rustfs_log_writer.set(logs_vec.into_iter().collect());
+            rustfs_log_writer.set(logs_vec.into_iter().map(to_log_entry).collect());
         }
     });
 
     let launch_rustfs = move |ev: SubmitEvent| {
         ev.prevent_default();
         set_is_running.set(true);
+        set_can_stop.set(true);
         show_toast("Launching RustFS...".to_string(), ToastType::Info);
 
-        let now = js_sys::Date::new_0().to_locale_time_string("en-US".into());
+        let now = js_sys::Date::new_0().to_locale_time_string("en-US");
         push_log(
             set_app_logs,
             format!("[{}] Launch button clicked", now),
@@ -260,7 +345,11 @@ pub fn App() -> impl IntoView {
         );
         push_log(
             set_app_logs,
-            format!("[{}] Config: {:?}", now, config.get()),
+            format!(
+                "[{}] Config summary: {}",
+                now,
+                describe_config(&config.get())
+            ),
             APP_LOG_CAPACITY,
         );
 
@@ -277,6 +366,7 @@ pub fn App() -> impl IntoView {
                     APP_LOG_CAPACITY,
                 );
                 set_is_running.set(false);
+                set_can_stop.set(false);
                 return;
             }
 
@@ -290,7 +380,7 @@ pub fn App() -> impl IntoView {
                 current_config.host
             );
 
-            let now = js_sys::Date::new_0().to_locale_time_string("en-US".into());
+            let now = js_sys::Date::new_0().to_locale_time_string("en-US");
             push_log(
                 set_app_logs,
                 format!("[{}] Calling tauri_invoke with command: launch_rustfs", now),
@@ -303,7 +393,7 @@ pub fn App() -> impl IntoView {
             js_sys::Reflect::set(&args, &"config".into(), &config_js).unwrap();
 
             let result_value = tauri_invoke("launch_rustfs", args.into()).await;
-            let now = js_sys::Date::new_0().to_locale_time_string("en-US".into());
+            let now = js_sys::Date::new_0().to_locale_time_string("en-US");
             push_log(
                 set_app_logs,
                 format!("[{}] Invoke result: {:?}", now, result_value),
@@ -312,7 +402,7 @@ pub fn App() -> impl IntoView {
 
             match serde_wasm_bindgen::from_value::<CommandResponse>(result_value) {
                 Ok(CommandResponse { success, message }) => {
-                    let now = js_sys::Date::new_0().to_locale_time_string("en-US".into());
+                    let now = js_sys::Date::new_0().to_locale_time_string("en-US");
                     push_log(
                         set_app_logs,
                         format!("[{}] Result message: {}", now, message),
@@ -324,7 +414,7 @@ pub fn App() -> impl IntoView {
                             "RustFS launched successfully!".to_string(),
                             ToastType::Success,
                         );
-                        let now = js_sys::Date::new_0().to_locale_time_string("en-US".into());
+                        let now = js_sys::Date::new_0().to_locale_time_string("en-US");
                         push_log(
                             set_app_logs,
                             format!("[{}] Launch successful!", now),
@@ -332,24 +422,26 @@ pub fn App() -> impl IntoView {
                         );
                     } else {
                         show_toast(format!("Launch failed: {}", message), ToastType::Error);
-                        let now = js_sys::Date::new_0().to_locale_time_string("en-US".into());
+                        let now = js_sys::Date::new_0().to_locale_time_string("en-US");
                         push_log(
                             set_app_logs,
                             format!("[{}] Launch result: {}", now, message),
                             APP_LOG_CAPACITY,
                         );
                         set_is_running.set(false);
+                        set_can_stop.set(false);
                     }
                 }
                 Err(_) => {
                     show_toast("RustFS launch command failed".to_string(), ToastType::Error);
-                    let now = js_sys::Date::new_0().to_locale_time_string("en-US".into());
+                    let now = js_sys::Date::new_0().to_locale_time_string("en-US");
                     push_log(
                         set_app_logs,
                         format!("[{}] Launch completed but response parsing failed", now),
                         APP_LOG_CAPACITY,
                     );
                     set_is_running.set(false);
+                    set_can_stop.set(false);
                 }
             }
         });
@@ -370,6 +462,7 @@ pub fn App() -> impl IntoView {
                 Ok(res) => {
                     if res.success {
                         set_is_running.set(false);
+                        set_can_stop.set(false);
                         set_service_status.set(false);
                         show_toast("RustFS stopped".to_string(), ToastType::Success);
                         push_log(
@@ -402,14 +495,48 @@ pub fn App() -> impl IntoView {
             <Toast toasts=toasts remove_toast=remove_toast />
 
             <div class="sidebar">
-                <div class="header">
+                <div class="header hero-card">
+                    <span class="eyebrow">"Control Plane"</span>
                     <h1>"RustFS Launcher"</h1>
-                    <p class="subtitle">"Simple launcher for RustFS project"</p>
-                    <div class="service-indicator" class:online=move || service_status.get()>
-                        <span class="status-dot"></span>
-                        <span class="status-text">
-                            {move || if service_status.get() { "Service Online" } else { "Service Offline" }}
-                        </span>
+
+                    <div class="status-cluster">
+                        <div class="service-indicator" class:online=move || service_status.get()>
+                            <span class="status-dot"></span>
+                            <span class="status-text">
+                                {move || if service_status.get() { "Service Online" } else { "Service Offline" }}
+                            </span>
+                        </div>
+                        <div class="launcher-indicator" class:managed=move || can_stop.get()>
+                            {move || if can_stop.get() {
+                                "Managed by Launcher"
+                            } else if is_running.get() {
+                                "Detected Externally"
+                            } else {
+                                "Ready to Launch"
+                            }}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="summary-grid">
+                    <div class="summary-card">
+                        <span class="summary-label">"API"</span>
+                        <strong>{move || format!(":{}", config.get().port.unwrap_or(DEFAULT_RUSTFS_PORT))}</strong>
+                    </div>
+                    <div class="summary-card">
+                        <span class="summary-label">"Console"</span>
+                        <strong>{move || {
+                            let current = config.get();
+                            if current.console_enable {
+                                format!(":{}", current.console_port.unwrap_or(DEFAULT_CONSOLE_PORT))
+                            } else {
+                                "Disabled".to_string()
+                            }
+                        }}</strong>
+                    </div>
+                    <div class="summary-card">
+                        <span class="summary-label">"Mode"</span>
+                        <strong>{move || if is_running.get() { "Locked" } else { "Editable" }}</strong>
                     </div>
                 </div>
 
@@ -417,6 +544,7 @@ pub fn App() -> impl IntoView {
                     config=config
                     set_config=set_config
                     is_running=is_running
+                    can_stop=can_stop
                     on_launch=Callback::new(launch_rustfs)
                     on_stop=Callback::new(stop_rustfs)
                 />

--- a/src/components/config_form.rs
+++ b/src/components/config_form.rs
@@ -12,18 +12,128 @@ extern "C" {
     async fn open(options: JsValue) -> JsValue;
 }
 
+const API_PORT_ERROR_MESSAGE: &str = "API port must be a number between 1 and 65535";
+const CONSOLE_PORT_ERROR_MESSAGE: &str = "Console port must be a number between 1 and 65535";
+const PORT_CONFLICT_ERROR_MESSAGE: &str = "API port and console port must be different";
+const DEFAULT_API_PORT: u16 = 9000;
+const DEFAULT_CONSOLE_PORT: u16 = 9001;
+
+fn parse_port_input(value: &str, error_message: &'static str) -> Result<Option<u16>, &'static str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let port = trimmed.parse::<u16>().map_err(|_| error_message)?;
+
+    if port == 0 {
+        return Err(error_message);
+    }
+
+    Ok(Some(port))
+}
+
+fn validate_port_conflict(
+    config: &RustFsConfig,
+    api_port: Option<u16>,
+    console_port: Option<u16>,
+) -> Result<(), &'static str> {
+    if !config.console_enable {
+        return Ok(());
+    }
+
+    let effective_api_port = api_port.unwrap_or(DEFAULT_API_PORT);
+    let effective_console_port = console_port.unwrap_or(DEFAULT_CONSOLE_PORT);
+
+    if effective_api_port == effective_console_port {
+        return Err(PORT_CONFLICT_ERROR_MESSAGE);
+    }
+
+    Ok(())
+}
+
 #[component]
 pub fn ConfigForm(
     #[prop(into)] config: Signal<RustFsConfig>,
     #[prop(into)] set_config: WriteSignal<RustFsConfig>,
     #[prop(into)] is_running: Signal<bool>,
+    #[prop(into)] can_stop: Signal<bool>,
     #[prop(into)] on_launch: Callback<SubmitEvent>,
     #[prop(into)] on_stop: Callback<()>,
 ) -> impl IntoView {
     let (show_secret, set_show_secret) = signal(false);
     let (is_drag_over, set_is_drag_over) = signal(false);
+    let (error_message, set_error_message) = signal(Option::<String>::None);
+    let (port_input, set_port_input) = signal(
+        config
+            .get_untracked()
+            .port
+            .map(|p| p.to_string())
+            .unwrap_or_default(),
+    );
+    let (console_port_input, set_console_port_input) = signal(
+        config
+            .get_untracked()
+            .console_port
+            .map(|p| p.to_string())
+            .unwrap_or_default(),
+    );
 
-    // Setup Tauri File Drop listener
+    let clear_related_error = move |messages: &[&'static str]| {
+        set_error_message.update(|error| {
+            if let Some(current) = error.as_deref() {
+                if messages.contains(&current) {
+                    *error = None;
+                }
+            }
+        });
+    };
+
+    let validate_and_store_api_port = move |value: String| {
+        set_port_input.set(value.clone());
+
+        match parse_port_input(&value, API_PORT_ERROR_MESSAGE) {
+            Ok(port) => {
+                let current = config.get_untracked();
+                set_config.update(|c| c.port = port);
+
+                match validate_port_conflict(&current, port, current.console_port) {
+                    Ok(()) => {
+                        clear_related_error(&[API_PORT_ERROR_MESSAGE, PORT_CONFLICT_ERROR_MESSAGE])
+                    }
+                    Err(message) => set_error_message.set(Some(message.to_string())),
+                }
+            }
+            Err(message) => {
+                set_config.update(|c| c.port = None);
+                set_error_message.set(Some(message.to_string()));
+            }
+        }
+    };
+
+    let validate_and_store_console_port = move |value: String| {
+        set_console_port_input.set(value.clone());
+
+        match parse_port_input(&value, CONSOLE_PORT_ERROR_MESSAGE) {
+            Ok(console_port) => {
+                let current = config.get_untracked();
+                set_config.update(|c| c.console_port = console_port);
+
+                match validate_port_conflict(&current, current.port, console_port) {
+                    Ok(()) => clear_related_error(&[
+                        CONSOLE_PORT_ERROR_MESSAGE,
+                        PORT_CONFLICT_ERROR_MESSAGE,
+                    ]),
+                    Err(message) => set_error_message.set(Some(message.to_string())),
+                }
+            }
+            Err(message) => {
+                set_config.update(|c| c.console_port = None);
+                set_error_message.set(Some(message.to_string()));
+            }
+        }
+    };
+
     Effect::new(move |_| {
         spawn_local(async move {
             if let Some(window) = web_sys::window() {
@@ -32,9 +142,13 @@ pub fn ConfigForm(
                         if let Ok(listen) = js_sys::Reflect::get(&event, &"listen".into()) {
                             let listen_fn = js_sys::Function::from(listen);
 
-                            // Handle File Drop
                             let drop_handler = Closure::wrap(Box::new(move |event: JsValue| {
                                 set_is_drag_over.set(false);
+
+                                if is_running.get_untracked() {
+                                    return;
+                                }
+
                                 if let Ok(payload) = js_sys::Reflect::get(&event, &"payload".into())
                                 {
                                     if let Ok(paths) =
@@ -42,19 +156,20 @@ pub fn ConfigForm(
                                     {
                                         if let Some(first_path) = paths.first() {
                                             set_config.update(|c| c.data_path = first_path.clone());
+                                            set_error_message.set(None);
                                         }
                                     }
                                 }
                             })
                                 as Box<dyn FnMut(JsValue)>);
 
-                            // Handle Drag Hover (Enter)
                             let hover_handler = Closure::wrap(Box::new(move |_: JsValue| {
-                                set_is_drag_over.set(true);
+                                if !is_running.get_untracked() {
+                                    set_is_drag_over.set(true);
+                                }
                             })
                                 as Box<dyn FnMut(JsValue)>);
 
-                            // Handle Drag Cancel (Leave)
                             let cancel_handler = Closure::wrap(Box::new(move |_: JsValue| {
                                 set_is_drag_over.set(false);
                             })
@@ -87,6 +202,10 @@ pub fn ConfigForm(
     });
 
     let select_folder = move |_| {
+        if is_running.get() {
+            return;
+        }
+
         spawn_local(async move {
             let options = serde_wasm_bindgen::to_value(&serde_json::json!({
                 "directory": true,
@@ -97,186 +216,313 @@ pub fn ConfigForm(
             if let Some(result) = open(options).await.as_string() {
                 if !result.is_empty() {
                     set_config.update(|c| c.data_path = result);
+                    set_error_message.set(None);
                 }
             }
         });
     };
 
-    let (error_message, set_error_message) = signal(Option::<String>::None);
-
     let handle_submit = move |ev: SubmitEvent| {
         ev.prevent_default();
 
         if is_running.get() {
-            // Stop mode
-            on_stop.run(());
-        } else {
-            // Launch mode
-            set_error_message.set(None);
+            if can_stop.get() {
+                on_stop.run(());
+            }
+            return;
+        }
 
-            let current_config = config.get();
+        set_error_message.set(None);
 
-            if current_config.data_path.trim().is_empty() {
-                set_error_message.set(Some("Data path is required".to_string()));
+        let current_config = config.get();
+
+        if current_config.data_path.trim().is_empty() {
+            set_error_message.set(Some("Data path is required".to_string()));
+            return;
+        }
+
+        let port = match parse_port_input(&port_input.get(), API_PORT_ERROR_MESSAGE) {
+            Ok(port) => port,
+            Err(message) => {
+                set_error_message.set(Some(message.to_string()));
                 return;
             }
+        };
 
-            if let Some(port) = current_config.port {
-                if port == 0 {
-                    set_error_message.set(Some("Port must be greater than 0".to_string()));
+        let console_port = if current_config.console_enable {
+            match parse_port_input(&console_port_input.get(), CONSOLE_PORT_ERROR_MESSAGE) {
+                Ok(console_port) => console_port,
+                Err(message) => {
+                    set_error_message.set(Some(message.to_string()));
                     return;
                 }
             }
+        } else {
+            current_config.console_port
+        };
 
-            on_launch.run(ev);
+        if let Err(message) = validate_port_conflict(&current_config, port, console_port) {
+            set_error_message.set(Some(message.to_string()));
+            return;
         }
+
+        set_config.update(|c| {
+            c.port = port;
+            c.console_port = console_port;
+        });
+
+        on_launch.run(ev);
     };
 
     view! {
-        <form class="config-form" on:submit=handle_submit>
-            <div class="form-group">
-                <label for="data-path">"Data Path" <span class="required">"*"</span></label>
-                <div
-                    class="path-input-group"
-                    class:drag-over=move || is_drag_over.get()
-                >
-                    <input
-                        id="data-path"
-                        type="text"
-                        placeholder="Select or drop data directory..."
-                        prop:value=move || config.get().data_path
-                        on:input=move |ev| {
-                            let value = event_target_value(&ev);
-                            set_config.update(|c| c.data_path = value.clone());
-                            if !value.is_empty() {
-                                set_error_message.set(None);
-                            }
-                        }
-                    />
-                    <button type="button" class="browse-btn" on:click=select_folder>
-                        "Browse"
-                    </button>
+        <form class="config-form" class:locked=move || is_running.get() on:submit=handle_submit>
+            <Show when=move || is_running.get()>
+                <div class="lock-banner">
+                    <span class="lock-banner-label">"Configuration Locked"</span>
                 </div>
-            </div>
+            </Show>
 
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="port">"Port"</label>
-                    <input
-                        id="port"
-                        type="number"
-                        placeholder="8080"
-                        min="1"
-                        max="65535"
-                        prop:value=move || config.get().port.map(|p| p.to_string()).unwrap_or_default()
-                        on:input=move |ev| {
-                            let value = event_target_value(&ev);
-                            let port = if value.is_empty() { None } else { value.parse().ok() };
-                            set_config.update(|c| c.port = port);
-                        }
-                    />
-                </div>
-                <div class="form-group">
-                    <label for="host">"Host"</label>
-                    <input
-                        id="host"
-                        type="text"
-                        placeholder="127.0.0.1"
-                        prop:value=move || config.get().host.unwrap_or_default()
-                        on:input=move |ev| {
-                            let value = event_target_value(&ev);
-                            let host = if value.is_empty() { None } else { Some(value) };
-                            set_config.update(|c| c.host = host);
-                        }
-                    />
-                </div>
-            </div>
+            <div class="control-surface">
+                <section class="form-section">
+                    <div class="section-header">
+                        <span class="section-tag">"Storage"</span>
+                        <h2>"Dataset Mount"</h2>
+                    </div>
 
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="access-key">"Access Key"</label>
-                    <input
-                        id="access-key"
-                        type="text"
-                        placeholder="rustfsadmin"
-                        prop:value=move || config.get().access_key.unwrap_or_default()
-                        on:input=move |ev| {
-                            let value = event_target_value(&ev);
-                            let access_key = if value.is_empty() { None } else { Some(value) };
-                            set_config.update(|c| c.access_key = access_key);
-                        }
-                    />
-                </div>
-                <div class="form-group">
-                    <label for="secret-key">"Secret Key"</label>
-                    <div class="input-with-toggle">
-                        <input
-                            id="secret-key"
-                            type=move || if show_secret.get() { "text" } else { "password" }
-                            placeholder="rustfsadmin"
-                            prop:value=move || config.get().secret_key.unwrap_or_default()
-                            on:input=move |ev| {
-                                let value = event_target_value(&ev);
-                                let secret_key = if value.is_empty() { None } else { Some(value) };
-                                set_config.update(|c| c.secret_key = secret_key);
-                            }
-                        />
-                        <button
-                            type="button"
-                            class="toggle-visibility"
-                            on:click=move |_| set_show_secret.update(|show| *show = !*show)
-                            title=move || if show_secret.get() { "Hide Secret" } else { "Show Secret" }
+                    <div class="form-group">
+                        <label for="data-path">"Data Path" <span class="required">"*"</span></label>
+                        <div
+                            class="path-input-group"
+                            class:drag-over=move || is_drag_over.get() && !is_running.get()
                         >
-                            {move || if show_secret.get() {
-                                view! {
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
-                                        <line x1="1" y1="1" x2="23" y2="23"></line>
-                                    </svg>
-                                }.into_any()
-                            } else {
-                                view! {
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-                                        <circle cx="12" cy="12" r="3"></circle>
-                                    </svg>
-                                }.into_any()
-                            }}
-                        </button>
+                            <input
+                                id="data-path"
+                                type="text"
+                                placeholder="Select or drop data directory..."
+                                prop:value=move || config.get().data_path
+                                disabled=move || is_running.get()
+                                on:input=move |ev| {
+                                    let value = event_target_value(&ev);
+                                    set_config.update(|c| c.data_path = value.clone());
+                                    if !value.is_empty() {
+                                        set_error_message.set(None);
+                                    }
+                                }
+                            />
+                            <button
+                                type="button"
+                                class="browse-btn"
+                                disabled=move || is_running.get()
+                                on:click=select_folder
+                            >
+                                "Browse"
+                            </button>
+                        </div>
                     </div>
-                </div>
-            </div>
+                </section>
 
-            <div class="form-row">
-                <div class="form-group">
-                    <div class="checkbox-group">
-                        <input
-                            id="console-enable"
-                            type="checkbox"
-                            prop:checked=move || config.get().console_enable
-                            on:change=move |ev| {
-                                let checked = event_target_checked(&ev);
-                                set_config.update(|c| c.console_enable = checked);
-                            }
-                        />
-                        <label for="console-enable">"Enable Console"</label>
+                <section class="form-section">
+                    <div class="section-header">
+                        <span class="section-tag">"Network"</span>
+                        <h2>"Ports & Access"</h2>
                     </div>
-                </div>
+
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="port">"API Port"</label>
+                            <input
+                                id="port"
+                                type="number"
+                                placeholder="9000"
+                                min="1"
+                                max="65535"
+                                prop:value=move || port_input.get()
+                                disabled=move || is_running.get()
+                                on:input=move |ev| validate_and_store_api_port(event_target_value(&ev))
+                            />
+                        </div>
+                        <div class="form-group">
+                            <label for="host">"Host"</label>
+                            <input
+                                id="host"
+                                type="text"
+                                placeholder="127.0.0.1"
+                                prop:value=move || config.get().host.unwrap_or_default()
+                                disabled=move || is_running.get()
+                                on:input=move |ev| {
+                                    let value = event_target_value(&ev);
+                                    let host = if value.is_empty() { None } else { Some(value) };
+                                    set_config.update(|c| c.host = host);
+                                }
+                            />
+                        </div>
+                    </div>
+
+                    <div class="runtime-toggle-row">
+                        <label class="toggle-card" class:disabled=move || is_running.get()>
+                            <input
+                                id="console-enable"
+                                type="checkbox"
+                                prop:checked=move || config.get().console_enable
+                                disabled=move || is_running.get()
+                                on:change=move |ev| {
+                                    let checked = event_target_checked(&ev);
+                                    set_config.update(|c| {
+                                        c.console_enable = checked;
+                                        if c.console_port.is_none() {
+                                            c.console_port = Some(DEFAULT_CONSOLE_PORT);
+                                        }
+                                    });
+                                    if checked {
+                                        let current_console_port = config
+                                            .get_untracked()
+                                            .console_port
+                                            .unwrap_or(DEFAULT_CONSOLE_PORT);
+                                        set_console_port_input.set(current_console_port.to_string());
+                                    }
+                                }
+                            />
+                            <span class="toggle-indicator"></span>
+                            <span class="toggle-copy">
+                                <strong>"Console Endpoint"</strong>
+                            </span>
+                        </label>
+                    </div>
+
+                    <Show when=move || config.get().console_enable>
+                        <div class="console-port-stack">
+                            <div class="form-group">
+                                <label for="console-port">"Console Port"</label>
+                                <input
+                                    id="console-port"
+                                    type="number"
+                                    placeholder="9001"
+                                    min="1"
+                                    max="65535"
+                                    prop:value=move || console_port_input.get()
+                                    disabled=move || is_running.get()
+                                    on:input=move |ev| {
+                                        validate_and_store_console_port(event_target_value(&ev))
+                                    }
+                                />
+                            </div>
+                            <div class="console-bind-inline">
+                                <span class="console-bind-label">"Console Bind"</span>
+                                <strong>
+                                    {move || {
+                                        let current = config.get();
+                                        format!(
+                                            "{}:{}",
+                                            current.host.unwrap_or_else(|| "127.0.0.1".to_string()),
+                                            current.console_port.unwrap_or(DEFAULT_CONSOLE_PORT)
+                                        )
+                                    }}
+                                </strong>
+                            </div>
+                        </div>
+                    </Show>
+                </section>
+
+                <section class="form-section">
+                    <div class="section-header">
+                        <span class="section-tag">"Security"</span>
+                        <h2>"Credentials"</h2>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="access-key">"Access Key"</label>
+                            <input
+                                id="access-key"
+                                type="text"
+                                placeholder="Access key"
+                                prop:value=move || config.get().access_key.unwrap_or_default()
+                                disabled=move || is_running.get()
+                                on:input=move |ev| {
+                                    let value = event_target_value(&ev);
+                                    let access_key = if value.is_empty() { None } else { Some(value) };
+                                    set_config.update(|c| c.access_key = access_key);
+                                }
+                            />
+                        </div>
+                        <div class="form-group">
+                            <label for="secret-key">"Secret Key"</label>
+                            <div class="input-with-toggle">
+                                <input
+                                    id="secret-key"
+                                    type=move || if show_secret.get() { "text" } else { "password" }
+                                    placeholder="Secret key"
+                                    prop:value=move || config.get().secret_key.unwrap_or_default()
+                                    disabled=move || is_running.get()
+                                    on:input=move |ev| {
+                                        let value = event_target_value(&ev);
+                                        let secret_key = if value.is_empty() { None } else { Some(value) };
+                                        set_config.update(|c| c.secret_key = secret_key);
+                                    }
+                                />
+                                <button
+                                    type="button"
+                                    class="toggle-visibility"
+                                    disabled=move || is_running.get()
+                                    on:click=move |_| {
+                                        if !is_running.get() {
+                                            set_show_secret.update(|show| *show = !*show);
+                                        }
+                                    }
+                                    title=move || if show_secret.get() { "Hide Secret" } else { "Show Secret" }
+                                >
+                                    {move || if show_secret.get() {
+                                        view! {
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                                <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+                                                <line x1="1" y1="1" x2="23" y2="23"></line>
+                                            </svg>
+                                        }
+                                            .into_any()
+                                    } else {
+                                        view! {
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                                                <circle cx="12" cy="12" r="3"></circle>
+                                            </svg>
+                                        }
+                                            .into_any()
+                                    }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </section>
             </div>
 
             <div class="form-actions">
                 <button
                     type="submit"
                     class="launch-btn"
-                    class:stop-btn=move || is_running.get()
-                    disabled=move || !is_running.get() && config.get().data_path.is_empty()
+                    class:stop-btn=move || can_stop.get()
+                    disabled=move || {
+                        config.get().data_path.is_empty() || (is_running.get() && !can_stop.get())
+                    }
                 >
-                    { move || if is_running.get() { "Stop RustFS" } else { "Launch RustFS" } }
+                    {move || {
+                        if can_stop.get() {
+                            "Stop RustFS"
+                        } else if is_running.get() {
+                            "RustFS Running"
+                        } else {
+                            "Launch RustFS"
+                        }
+                    }}
                 </button>
-                <Show when=move || error_message.get().is_some()>
-                    <div class="error-message">
-                        { move || error_message.get() }
+
+                <Show when=move || is_running.get() && !can_stop.get()>
+                    <div class="field-hint">
+                        "The configured RustFS service is online, but this launcher is not managing that process."
                     </div>
+                </Show>
+
+                <Show when=move || error_message.get().is_some()>
+                    <div class="error-message">{move || error_message.get()}</div>
                 </Show>
             </div>
         </form>

--- a/src/components/log_viewer.rs
+++ b/src/components/log_viewer.rs
@@ -1,13 +1,13 @@
-use crate::types::LogType;
+use crate::types::{LogEntry, LogType};
 use leptos::prelude::*;
 use std::collections::VecDeque;
 
 #[component]
 pub fn LogViewer(
-    #[prop(into)] app_logs: Signal<VecDeque<String>>,
-    #[prop(into)] set_app_logs: WriteSignal<VecDeque<String>>,
-    #[prop(into)] rustfs_logs: Signal<VecDeque<String>>,
-    #[prop(into)] set_rustfs_logs: WriteSignal<VecDeque<String>>,
+    #[prop(into)] app_logs: Signal<VecDeque<LogEntry>>,
+    #[prop(into)] set_app_logs: WriteSignal<VecDeque<LogEntry>>,
+    #[prop(into)] rustfs_logs: Signal<VecDeque<LogEntry>>,
+    #[prop(into)] set_rustfs_logs: WriteSignal<VecDeque<LogEntry>>,
     #[prop(into)] current_log_type: Signal<LogType>,
     #[prop(into)] set_current_log_type: WriteSignal<LogType>,
 ) -> impl IntoView {
@@ -77,10 +77,10 @@ pub fn LogViewer(
                         .into_iter()
                         .collect::<Vec<_>>()
                     }
-                    key=|log| log.clone()
+                    key=|log| log.id
                     let:log
                 >
-                    <div class="log-line">{log}</div>
+                    <div class="log-line">{log.message}</div>
                 </For>
                 <Show when=move || {
                     match current_log_type.get() {

--- a/src/logs.css
+++ b/src/logs.css
@@ -1,150 +1,157 @@
-/* This file is injected into the app, so it can use variables from styles.css */
-
 .logs-section {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    background-color: #000000; /* Deep black for terminal feel */
-    overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(circle at top right, rgba(255, 138, 61, 0.09), transparent 22%),
+    linear-gradient(180deg, rgba(5, 10, 19, 0.94), rgba(3, 7, 14, 0.98));
 }
 
 .log-panel {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    width: 100%;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .log-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background-color: #18181b;
-    border-bottom: 1px solid #333;
-    padding-right: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(151, 178, 214, 0.12);
+  background: rgba(12, 20, 34, 0.78);
+  backdrop-filter: blur(14px);
 }
 
 .log-tabs {
-    display: flex;
+  display: inline-flex;
+  gap: 8px;
+  padding: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .log-tab {
-    background: transparent;
-    border: none;
-    color: #71717a;
-    padding: 10px 20px;
-    font-size: 0.85rem;
-    cursor: pointer;
-    transition: color 0.2s, background-color 0.2s;
-    border-right: 1px solid #333;
+  border: none;
+  border-radius: 999px;
+  padding: 9px 14px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
 }
 
 .log-tab:hover {
-    color: #d4d4d8;
-    background-color: #27272a;
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .log-tab.active {
-    color: #fff;
-    background-color: #000; /* Matches log output bg */
-    border-top: 2px solid var(--accent-color);
+  color: #0d1725;
+  background: linear-gradient(135deg, var(--accent-color), #ffbc79);
 }
 
 .log-actions {
-    display: flex;
-    align-items: center;
-    gap: 15px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .auto-scroll-toggle {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    color: #94a3b8;
-    font-size: 0.8rem;
-    cursor: pointer;
-    user-select: none;
-}
-
-.auto-scroll-toggle:hover {
-    color: #e2e8f0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
 }
 
 .clear-btn {
-    background: transparent;
-    border: 1px solid #475569;
-    color: #94a3b8;
-    border-radius: 4px;
-    padding: 4px 8px;
-    font-size: 0.75rem;
-    cursor: pointer;
-    transition: all 0.2s;
+  border: 1px solid rgba(151, 178, 214, 0.16);
+  border-radius: 12px;
+  padding: 8px 10px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-secondary);
+  font-size: 0.77rem;
+  font-weight: 700;
 }
 
 .clear-btn:hover {
-    color: #ef4444;
-    border-color: #ef4444;
-    background-color: rgba(239, 68, 68, 0.1);
+  color: #ffd0d0;
+  border-color: rgba(255, 107, 107, 0.28);
+  background: rgba(255, 107, 107, 0.08);
 }
 
 .log-output {
-    flex: 1;
-    padding: 1rem;
-    overflow-y: auto;
-    font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
-    font-size: 13px;
-    line-height: 1.6; /* Increased from 1.5/1.6? Wait, I set 1.6 before. Let's go 1.7 for more breathing room. */
-    color: #e4e4e7;
-    white-space: pre-wrap;
-    position: relative;
-}
-
-.empty-logs {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    color: #52525b;
-    font-style: italic;
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  overflow-y: auto;
+  padding: 18px;
+  font-family: "JetBrains Mono", "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 12.5px;
+  line-height: 1.72;
+  color: #dbeafe;
+  white-space: pre-wrap;
 }
 
 .log-line {
-    margin-bottom: 2px;
+  padding: 2px 10px;
+  margin-bottom: 4px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.015);
 }
 
-/* Log Levels / Highlighting */
-.log-line:contains("ERROR"), .log-line:contains("error") {
-    color: #f87171;
+.empty-logs {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+  font-style: italic;
 }
 
-.log-line:contains("WARN"), .log-line:contains("warn") {
-    color: #fbbf24;
-}
-
-.log-line:contains("INFO"), .log-line:contains("info") {
-    color: #60a5fa;
-}
-
-.log-line:contains("SUCCESS"), .log-line:contains("success") {
-    color: #34d399;
-}
-
-/* Scrollbar for Logs */
 .log-output::-webkit-scrollbar {
-    width: 10px;
+  width: 10px;
 }
 
 .log-output::-webkit-scrollbar-track {
-    background: #18181b;
+  background: transparent;
 }
 
 .log-output::-webkit-scrollbar-thumb {
-    background: #3f3f46;
-    border-radius: 5px;
-    border: 2px solid #18181b;
+  border-radius: 999px;
+  background: rgba(151, 178, 214, 0.2);
+  border: 2px solid transparent;
 }
 
 .log-output::-webkit-scrollbar-thumb:hover {
-    background: #52525b;
+  background: rgba(151, 178, 214, 0.34);
+}
+
+@media (max-width: 720px) {
+  .log-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .log-actions {
+    justify-content: space-between;
+  }
+
+  .log-tabs {
+    width: 100%;
+  }
+
+  .log-tab {
+    flex: 1;
+    text-align: center;
+  }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,16 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogEntry {
+    pub id: u64,
+    pub message: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct RustFsConfig {
     pub data_path: String,
     pub port: Option<u16>,
+    pub console_port: Option<u16>,
     pub host: Option<String>,
     pub access_key: Option<String>,
     pub secret_key: Option<String>,
@@ -15,6 +22,7 @@ impl Default for RustFsConfig {
         Self {
             data_path: String::new(),
             port: Some(9000),
+            console_port: Some(9001),
             host: Some("127.0.0.1".to_string()),
             access_key: Some("rustfsadmin".to_string()),
             secret_key: Some("rustfsadmin".to_string()),

--- a/styles.css
+++ b/styles.css
@@ -1,494 +1,664 @@
 :root {
-  /* Colors - Dark Theme */
-  --bg-primary: #0f172a;    /* Main window background (deep blue/black) */
-  --bg-sidebar: #1e293b;    /* Sidebar background */
-  --bg-input: #334155;      /* Input fields */
-  --text-primary: #f8fafc;  /* Main text */
-  --text-secondary: #94a3b8;/* Labels/Subtitles */
-  
-  --accent-color: #3b82f6;  /* Blue accent */
-  --accent-hover: #2563eb;
-  
-  --border-color: #334155;
-  
-  --success: #10b981;
-  --error: #ef4444;
-
-  /* Spacing */
-  --space-xs: 0.25rem;
-  --space-sm: 0.5rem;
+  --bg-page: #07111e;
+  --bg-page-accent: #122746;
+  --bg-panel: rgba(10, 23, 42, 0.9);
+  --bg-card: rgba(18, 34, 58, 0.92);
+  --bg-card-strong: rgba(25, 45, 73, 0.98);
+  --bg-input: rgba(7, 17, 32, 0.78);
+  --bg-input-disabled: rgba(7, 17, 32, 0.45);
+  --text-primary: #eff6ff;
+  --text-secondary: #8fa7c8;
+  --text-muted: #5f7594;
+  --accent-color: #ff8a3d;
+  --accent-hover: #ffa35a;
+  --accent-soft: rgba(255, 138, 61, 0.16);
+  --success: #39d0a4;
+  --success-soft: rgba(57, 208, 164, 0.14);
+  --error: #ff6b6b;
+  --error-soft: rgba(255, 107, 107, 0.14);
+  --border-color: rgba(151, 178, 214, 0.14);
+  --shadow-lg: 0 24px 80px rgba(0, 0, 0, 0.35);
+  --space-xs: 0.3rem;
+  --space-sm: 0.65rem;
   --space-md: 1rem;
   --space-lg: 1.5rem;
-  
-  /* Radius */
-  --radius: 6px;
+  --space-xl: 2rem;
+  --radius-sm: 12px;
+  --radius-md: 20px;
+  --radius-lg: 28px;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html,
+body {
+  min-height: 100%;
+}
+
 body {
   margin: 0;
-  padding: 0;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background-color: var(--bg-primary);
+  font-family: "Avenir Next", "IBM Plex Sans", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at top left, rgba(255, 138, 61, 0.18), transparent 32%),
+    radial-gradient(circle at top right, rgba(37, 99, 235, 0.22), transparent 28%),
+    linear-gradient(145deg, var(--bg-page) 0%, var(--bg-page-accent) 100%);
   color: var(--text-primary);
-  height: 100vh;
+  min-height: 100vh;
   overflow: hidden;
-  font-size: 14px;
 }
 
-/* Layout */
+button,
+input {
+  font: inherit;
+}
+
 .container {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(360px, 430px) minmax(0, 1fr);
+  gap: 22px;
   height: 100vh;
-  width: 100vw;
+  padding: 22px;
+  overflow: hidden;
 }
 
-/* Sidebar (Left Panel) */
 .sidebar {
-  width: 300px;
-  background-color: var(--bg-sidebar);
-  border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
-  padding: var(--space-lg);
-  flex-shrink: 0;
-  overflow-y: auto;
+  gap: 18px;
+  min-height: 0;
+  overflow: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 
-.header {
-  margin-bottom: var(--space-lg);
+.sidebar::-webkit-scrollbar {
+  display: none;
+}
+
+.sidebar > * {
+  flex-shrink: 0;
+}
+
+.hero-card,
+.summary-card,
+.control-surface,
+.logs-section {
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-lg);
+}
+
+.hero-card {
+  position: relative;
+  overflow: hidden;
+  padding: 24px 24px 30px;
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(circle at top right, rgba(255, 138, 61, 0.18), transparent 28%),
+    linear-gradient(160deg, rgba(19, 38, 63, 0.98), rgba(10, 20, 37, 0.96));
+}
+
+.hero-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(125deg, transparent 20%, rgba(255, 255, 255, 0.04) 20%, transparent 40%),
+    linear-gradient(180deg, transparent, rgba(255, 255, 255, 0.02));
+  pointer-events: none;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--accent-hover);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
 .header h1 {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: var(--text-primary);
+  margin: 12px 0 0;
+  font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+  font-size: 2.35rem;
+  line-height: 1;
+  letter-spacing: -0.03em;
 }
 
-.subtitle {
-  margin: var(--space-xs) 0 0;
+.status-cluster {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.service-indicator,
+.launcher-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  background: rgba(255, 255, 255, 0.06);
   color: var(--text-secondary);
-  font-size: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
 }
 
-/* Config Form */
+.launcher-indicator.managed {
+  color: var(--accent-hover);
+  background: rgba(255, 138, 61, 0.12);
+}
+
+.status-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--error);
+  box-shadow: 0 0 0 0 rgba(255, 107, 107, 0.5);
+}
+
+.service-indicator.online {
+  color: var(--success);
+  background: var(--success-soft);
+}
+
+.service-indicator.online .status-dot {
+  background: var(--success);
+  animation: pulse-green 2s infinite;
+}
+
+@keyframes pulse-green {
+  0% { box-shadow: 0 0 0 0 rgba(57, 208, 164, 0.45); }
+  70% { box-shadow: 0 0 0 10px rgba(57, 208, 164, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(57, 208, 164, 0); }
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.summary-card {
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(180deg, rgba(20, 36, 58, 0.92), rgba(10, 20, 35, 0.9));
+}
+
+.summary-label {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.summary-card strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
 .config-form {
   display: flex;
   flex-direction: column;
-  gap: var(--space-md);
+  gap: 16px;
+  min-height: 0;
+}
+
+.lock-banner {
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 138, 61, 0.22);
+  background: linear-gradient(135deg, rgba(255, 138, 61, 0.14), rgba(255, 138, 61, 0.05));
+}
+
+.lock-banner-label {
+  display: block;
+  color: var(--accent-hover);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.control-surface {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px;
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, rgba(11, 22, 39, 0.94), rgba(7, 16, 30, 0.96));
+}
+
+.form-section {
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(180deg, rgba(16, 31, 51, 0.82), rgba(8, 18, 31, 0.86));
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.section-header {
+  margin-bottom: 12px;
+}
+
+.section-tag {
+  display: inline-flex;
+  color: var(--accent-hover);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.section-header h2 {
+  margin: 8px 0 0;
+  font-size: 1.05rem;
+  line-height: 1.2;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.form-group + .form-group,
+.form-row + .form-row,
+.runtime-toggle-row,
+.form-section .form-group {
+  margin-top: 12px;
 }
 
 .form-group label {
   display: block;
+  margin-bottom: 7px;
   color: var(--text-secondary);
-  margin-bottom: var(--space-xs);
-  font-size: 0.8rem;
-  font-weight: 500;
+  font-size: 0.79rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 .required {
   color: var(--accent-color);
 }
 
-.form-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-md);
-}
-
-/* Service Indicator */
-.service-indicator {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: var(--space-sm);
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-  background: rgba(255, 255, 255, 0.05);
-  padding: 4px 8px;
-  border-radius: 12px;
-  width: fit-content;
-}
-
-.status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background-color: var(--error);
-  transition: background-color 0.3s;
-  box-shadow: 0 0 4px rgba(239, 68, 68, 0.4);
-}
-
-.service-indicator.online .status-dot {
-  background-color: var(--success);
-  box-shadow: 0 0 4px rgba(16, 185, 129, 0.4);
-}
-
-.service-indicator.online {
-  color: var(--success);
-  background: rgba(16, 185, 129, 0.1);
-}
-
 input[type="text"],
 input[type="number"],
 input[type="password"] {
   width: 100%;
-  background-color: var(--bg-input);
+  min-height: 46px;
+  padding: 0.78rem 0.9rem;
   border: 1px solid transparent;
-  border-radius: var(--radius);
-  padding: 0.6rem 0.75rem;
+  border-radius: 14px;
+  background: var(--bg-input);
   color: var(--text-primary);
-  font-size: 0.9rem;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition: border-color 0.2s, box-shadow 0.2s, background-color 0.2s, opacity 0.2s;
+}
+
+input::placeholder {
+  color: rgba(143, 167, 200, 0.52);
 }
 
 input:focus {
   outline: none;
-  border-color: var(--accent-color);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+  border-color: rgba(255, 138, 61, 0.55);
+  box-shadow: 0 0 0 4px rgba(255, 138, 61, 0.14);
 }
 
-/* Path Input Group */
+input:disabled,
+button:disabled {
+  cursor: not-allowed;
+}
+
+input:disabled {
+  background: var(--bg-input-disabled);
+  color: rgba(239, 246, 255, 0.6);
+  border-color: rgba(255, 255, 255, 0.03);
+}
+
 .path-input-group {
-  display: flex;
-  gap: var(--space-sm);
-  transition: all 0.2s;
-  border: 2px solid transparent; /* Reserve space for border */
-  border-radius: var(--radius);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  border-radius: 18px;
+  transition: border-color 0.2s, background-color 0.2s, transform 0.2s;
 }
 
 .path-input-group.drag-over {
-  border: 2px dashed var(--accent-color);
-  background-color: rgba(59, 130, 246, 0.1);
-  padding: 4px; /* Add padding to contain the inputs visually inside the dashed area */
-  margin: -4px; /* Negate padding to prevent layout shift */
+  background: rgba(255, 138, 61, 0.08);
+  outline: 1px dashed rgba(255, 138, 61, 0.45);
+  outline-offset: 6px;
+}
+
+.browse-btn,
+.launch-btn,
+.toggle-visibility,
+.log-tab,
+.clear-btn {
+  transition: transform 0.16s ease, background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
 .browse-btn {
-  background-color: var(--bg-input);
-  border: 1px solid var(--border-color);
+  min-width: 96px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  background: var(--bg-card-strong);
   color: var(--text-primary);
-  padding: 0 0.75rem;
-  border-radius: var(--radius);
-  cursor: pointer;
-  font-size: 0.85rem;
-  white-space: nowrap;
-  transition: background-color 0.2s;
 }
 
-.browse-btn:hover {
-  background-color: #475569;
+.browse-btn:hover:not(:disabled) {
+  background: rgba(255, 138, 61, 0.15);
+  border-color: rgba(255, 138, 61, 0.25);
+  transform: translateY(-1px);
 }
 
-/* Toggle Visibility Button */
 .input-with-toggle {
   position: relative;
-  display: flex;
 }
 
 .toggle-visibility {
   position: absolute;
-  right: 0;
-  top: 0;
-  bottom: 0;
+  top: 5px;
+  right: 5px;
+  bottom: 5px;
+  width: 42px;
+  border: none;
+  border-radius: 12px;
   background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 0 0.75rem;
-  font-size: 1rem;
-  display: flex;
+  color: var(--text-secondary);
+}
+
+.toggle-visibility:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+}
+
+.runtime-toggle-row {
+  margin-top: 16px;
+}
+
+.toggle-card {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
   align-items: center;
-  opacity: 0.6;
-  transition: opacity 0.2s;
-}
-
-.toggle-visibility:hover {
-  opacity: 1;
-}
-
-/* Checkbox */
-.checkbox-group {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-}
-
-.checkbox-group input {
-  margin: 0;
-}
-
-.checkbox-group label {
-  margin: 0;
+  gap: 12px;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.03);
   cursor: pointer;
 }
 
-/* Buttons */
-.launch-btn {
-  background-color: var(--accent-color);
-  color: white;
-  border: none;
-  border-radius: var(--radius);
-  padding: 0.75rem;
-  font-weight: 600;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background-color 0.2s, transform 0.1s;
-  width: 100%;
+.toggle-card input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
 }
 
-.launch-btn:hover:not(:disabled) {
-  background-color: var(--accent-hover);
-}
-
-.launch-btn:active:not(:disabled) {
-  transform: translateY(1px);
-}
-
-.launch-btn:disabled {
-  opacity: 0.5;
+.toggle-card.disabled {
+  opacity: 0.58;
   cursor: not-allowed;
 }
 
+.toggle-indicator {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  position: relative;
+}
+
+.toggle-indicator::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s ease;
+}
+
+.toggle-card input:checked + .toggle-indicator {
+  background: rgba(255, 138, 61, 0.55);
+}
+
+.toggle-card input:checked + .toggle-indicator::after {
+  transform: translateX(20px);
+}
+
+.toggle-copy strong {
+  display: block;
+  font-size: 0.92rem;
+}
+
+.console-port-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.console-bind-inline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.console-bind-label {
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.console-bind-inline strong {
+  font-size: 0.92rem;
+  word-break: break-all;
+  text-align: right;
+}
+
+.form-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.launch-btn {
+  width: 100%;
+  min-height: 54px;
+  border: none;
+  border-radius: 18px;
+  background: linear-gradient(135deg, var(--accent-color), #ffb066);
+  color: #0e1726;
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.launch-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: linear-gradient(135deg, var(--accent-hover), #ffb777);
+}
+
 .stop-btn {
-  background-color: var(--error);
+  background: linear-gradient(135deg, #ff7676, #ff5a5a);
+  color: #fff;
 }
 
 .stop-btn:hover:not(:disabled) {
-  background-color: #dc2626; /* Darker red */
+  background: linear-gradient(135deg, #ff6666, #ef4444);
 }
 
-/* Status */
-.status {
-  margin-top: auto;
-  padding: var(--space-md);
-  background-color: rgba(16, 185, 129, 0.1);
-  border: 1px solid rgba(16, 185, 129, 0.2);
-  border-radius: var(--radius);
-  color: var(--success);
-  font-size: 0.85rem;
-  text-align: center;
+.launch-btn:disabled {
+  opacity: 0.58;
 }
 
-.status.hidden {
-  display: none;
+.field-hint,
+.error-message {
+  padding: 12px 14px;
+  border-radius: 14px;
+  font-size: 0.84rem;
+  line-height: 1.5;
 }
 
-/* Toast Notifications */
-
-.toast-container {
-
-  position: fixed;
-
-  top: 20px;
-
-  left: 50%;
-
-  transform: translateX(-50%);
-
-  z-index: 1000;
-
-  display: flex;
-
-  flex-direction: column;
-
-  gap: 10px;
-
-  pointer-events: none; /* Allow clicks through container */
-
-}
-
-
-
-.toast-item {
-
-  pointer-events: auto;
-
-  background: rgba(30, 41, 59, 0.95);
-
-  backdrop-filter: blur(8px);
-
-  color: white;
-
-  padding: 12px 20px;
-
-  border-radius: 8px;
-
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-
-  display: flex;
-
-  align-items: center;
-
-  gap: 12px;
-
-  min-width: 300px;
-
-  animation: slideDown 0.3s ease-out forwards;
-
-  border-left: 4px solid transparent;
-
-  font-size: 0.9rem;
-
-}
-
-
-
-@keyframes slideDown {
-
-  from { opacity: 0; transform: translateY(-20px); }
-
-  to { opacity: 1; transform: translateY(0); }
-
-}
-
-
-
-.toast-item.success { border-left-color: var(--success); }
-
-.toast-item.error { border-left-color: var(--error); }
-
-.toast-item.info { border-left-color: var(--accent-color); }
-
-
-
-.toast-icon {
-
-  font-weight: bold;
-
-  font-size: 1.1rem;
-
-}
-
-
-
-.toast-item.success .toast-icon { color: var(--success); }
-
-.toast-item.error .toast-icon { color: var(--error); }
-
-.toast-item.info .toast-icon { color: var(--accent-color); }
-
-
-
-.toast-text {
-
-  flex: 1;
-
-}
-
-
-
-.toast-close {
-
-  background: none;
-
-  border: none;
-
+.field-hint {
   color: var(--text-secondary);
-
-  cursor: pointer;
-
-  font-size: 1.2rem;
-
-  padding: 0 4px;
-
-  line-height: 1;
-
+  background: rgba(255, 255, 255, 0.04);
 }
-
-
-
-.toast-close:hover {
-
-  color: white;
-
-}
-
-
-
-/* Service Indicator Pulse */
-
-@keyframes pulse-green {
-
-  0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4); }
-
-  70% { box-shadow: 0 0 0 6px rgba(16, 185, 129, 0); }
-
-  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
-
-}
-
-
-
-.service-indicator.online .status-dot {
-
-  background-color: var(--success);
-
-  animation: pulse-green 2s infinite;
-
-}
-
-
-
-/* Input Group Alignment */
-
-.path-input-group {
-
-  display: flex;
-
-  gap: var(--space-sm);
-
-  transition: all 0.2s;
-
-  border: 2px solid transparent;
-
-  border-radius: var(--radius);
-
-  align-items: stretch; /* Ensure input and button stretch to same height */
-
-}
-
-
-
-.path-input-group input {
-
-  height: 42px; /* Fix height explicitly for alignment */
-
-}
-
-
-
-.browse-btn {
-
-  height: 42px; /* Match input height */
-
-  display: flex;
-
-  align-items: center;
-
-}
-
-
-
-/* Error Message */
 
 .error-message {
-
-  color: var(--error);
-
-  font-size: 0.85rem;
-
-  margin-top: var(--space-sm);
-
-  text-align: center;
-
-  font-weight: 500;
-
-  animation: fadeIn 0.2s ease;
-
+  color: #ffd3d3;
+  background: var(--error-soft);
+  border: 1px solid rgba(255, 107, 107, 0.16);
 }
 
+.toast-container {
+  position: fixed;
+  top: 22px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  pointer-events: none;
+}
 
+.toast-item {
+  pointer-events: auto;
+  min-width: 320px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 13px 18px;
+  border-left: 4px solid transparent;
+  border-radius: 16px;
+  background: rgba(10, 22, 38, 0.95);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.28);
+  animation: slideDown 0.3s ease-out forwards;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.toast-item.success {
+  border-left-color: var(--success);
+}
+
+.toast-item.error {
+  border-left-color: var(--error);
+}
+
+.toast-item.info {
+  border-left-color: var(--accent-color);
+}
+
+.toast-icon {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.toast-item.success .toast-icon {
+  color: var(--success);
+}
+
+.toast-item.error .toast-icon {
+  color: var(--error);
+}
+
+.toast-item.info .toast-icon {
+  color: var(--accent-color);
+}
+
+.toast-text {
+  flex: 1;
+}
+
+.toast-close {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 1.15rem;
+}
+
+.toast-close:hover {
+  color: var(--text-primary);
+}
+
+@media (max-width: 1180px) {
+  .container {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    order: 1;
+  }
+
+  .logs-section {
+    min-height: 420px;
+  }
+}
+
+@media (max-width: 720px) {
+  .container {
+    padding: 14px;
+    gap: 14px;
+  }
+
+  .hero-card,
+  .control-surface,
+  .logs-section {
+    border-radius: 22px;
+  }
+
+  .summary-grid,
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .header h1 {
+    font-size: 2rem;
+  }
+
+  .status-cluster {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .path-input-group {
+    grid-template-columns: 1fr;
+  }
+
+  .browse-btn {
+    min-height: 46px;
+  }
+
+  .toast-item {
+    min-width: min(92vw, 320px);
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the launcher UI with a cleaner control panel and refreshed log area
- lock all configuration inputs while the service is running and improve runtime state sync
- add console port configuration, stricter port validation, and safer log/config handling

## Changes
- rebuilt the left-side control surface, summary cards, and log panel styling for a simpler cross-platform layout
- prevent editing data path, host, API port, console settings, and credentials while RustFS is running
- add managed-process status checks so the UI distinguishes launcher-managed processes from externally running services
- add console port support end-to-end, including persistence, form input, process arguments, and port-conflict validation
- restore explicit default values for access key, secret key, and console port in the form
- stop persisting credentials to local storage, redact secrets from logs, and avoid logging raw command-line credentials
- switch frontend log rendering to stable IDs so repeated log lines render correctly
- keep log scrolling inside the right-side panel and hide the left-panel scrollbar while preserving scroll behavior

## Validation
- cargo fmt --all --check
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

## Notes
- cargo test --workspace currently passes with 0 tests in this repository
- manually verified that omitting access/secret key still starts RustFS with its current default credentials