### PR TITLE
feat: add signed self-update flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,8 @@ jobs:
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          cargo install trunk tauri-cli
+          cargo install trunk --version 0.21.14 --locked
+          cargo install tauri-cli
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ on:
         description: "Release tag (e.g., 0.1.0). If provided, will build in release mode."
         required: false
         type: string
+      rustfs_tag:
+        description: "RustFS release tag to bundle. Defaults to the latest upstream release."
+        required: false
+        type: string
 
 jobs:
   # Build strategy check - determine build type and version
@@ -144,10 +148,10 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.build-check.outputs.release_tag }}
+          REQUESTED_RUSTFS_TAG: ${{ github.event.inputs.rustfs_tag }}
         run: |
-          if [[ -n "$RELEASE_TAG" ]]; then
-            tag="$RELEASE_TAG"
+          if [[ -n "$REQUESTED_RUSTFS_TAG" ]]; then
+            tag="$REQUESTED_RUSTFS_TAG"
             echo "🎯 Using requested upstream release: $tag"
             gh release view "$tag" --repo rustfs/rustfs >/dev/null
           else
@@ -161,6 +165,34 @@ jobs:
           fi
 
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "RUSTFS_VERSION=${tag#v}" >> "$GITHUB_ENV"
+
+      - name: Set launcher version
+        if: needs.build-check.outputs.is_release == 'true'
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.build-check.outputs.version }}
+        run: |
+          version="${RELEASE_VERSION#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "❌ Launcher version must be valid SemVer: $RELEASE_VERSION"
+            exit 1
+          fi
+
+          jq --arg version "$version" '.version = $version' \
+            src-tauri/tauri.conf.json > src-tauri/tauri.conf.json.tmp
+          mv src-tauri/tauri.conf.json.tmp src-tauri/tauri.conf.json
+          sed -i.bak -E "0,/^version = \"[^\"]+\"/s//version = \"$version\"/" src-tauri/Cargo.toml
+          rm -f src-tauri/Cargo.toml.bak
+          echo "LAUNCHER_VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Disable updater artifacts for development builds
+        if: needs.build-check.outputs.is_release != 'true'
+        shell: bash
+        run: |
+          jq '.bundle.createUpdaterArtifacts = false' \
+            src-tauri/tauri.conf.json > src-tauri/tauri.conf.json.tmp
+          mv src-tauri/tauri.conf.json.tmp src-tauri/tauri.conf.json
 
       - name: Download RustFS binary (macOS aarch64)
         if: matrix.platform == 'macos-latest'
@@ -211,16 +243,23 @@ jobs:
 
       - name: Build Tauri application (macOS)
         if: runner.os == 'macOS'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: cargo tauri build --target ${{ matrix.rust_target }} --bundles app
 
       - name: Build Tauri application (Windows)
         if: runner.os == 'Windows'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: cargo tauri build --target ${{ matrix.rust_target }}
 
       - name: Prepare and rename artifacts (macOS)
         if: runner.os == 'macOS'
         env:
           VERSION: ${{ needs.build-check.outputs.version }}
+          IS_RELEASE: ${{ needs.build-check.outputs.is_release }}
         run: |
           mkdir -p artifacts
 
@@ -232,6 +271,7 @@ jobs:
 
           # 在 workspace 内搜索打包输出，不依赖固定路径
           APP_DIR=$(find src-tauri target -path "*bundle/macos/*.app" -type d -print -quit 2>/dev/null || true)
+          UPDATER_FILE=$(find src-tauri target -path "*bundle/macos/*.app.tar.gz" -type f -print -quit 2>/dev/null || true)
           DMG_FILE=$(find src-tauri target -path "*bundle/dmg/*.dmg" -type f -print -quit 2>/dev/null || true)
 
           echo "发现的 .app 目录：${APP_DIR:-无}"
@@ -258,6 +298,18 @@ jobs:
             exit 1
           fi
 
+          if [ "$IS_RELEASE" != "true" ]; then
+            echo "ℹ️ Development build: updater artifact is disabled"
+          elif [ -n "$UPDATER_FILE" ] && [ -f "${UPDATER_FILE}.sig" ]; then
+            UPDATER_NAME="${ARTIFACT_PREFIX}.app.tar.gz"
+            cp "$UPDATER_FILE" "artifacts/$UPDATER_NAME"
+            cp "${UPDATER_FILE}.sig" "artifacts/${UPDATER_NAME}.sig"
+            echo "✅ Created updater: $UPDATER_NAME"
+          else
+            echo "❌ 未找到 macOS updater 产物或签名"
+            exit 1
+          fi
+
           # Create latest version files
           cd "$GITHUB_WORKSPACE/artifacts"
           LATEST_PREFIX="rustfs-launcher-${{ matrix.os_name }}-${{ matrix.arch }}-latest"
@@ -281,6 +333,7 @@ jobs:
         if: runner.os == 'Windows'
         env:
           VERSION: ${{ needs.build-check.outputs.version }}
+          IS_RELEASE: ${{ needs.build-check.outputs.is_release }}
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path artifacts
@@ -323,6 +376,14 @@ jobs:
           if ($exeFiles) {
             $destPath = "artifacts/$ARTIFACT_PREFIX-setup.exe"
             Copy-Item $exeFiles[0].FullName -Destination $destPath
+            $signaturePath = "$($exeFiles[0].FullName).sig"
+            if ($env:IS_RELEASE -eq "true" -and -not (Test-Path $signaturePath)) {
+              Write-Error "未找到 Windows updater 签名: $signaturePath"
+              exit 1
+            }
+            if (Test-Path $signaturePath) {
+              Copy-Item $signaturePath -Destination "$destPath.sig"
+            }
             Write-Host "✅ Created: $destPath"
             $artifactCount++
           } else {
@@ -478,6 +539,50 @@ jobs:
 
           echo "📦 Release assets:"
           ls -la
+
+      - name: Generate updater manifest
+        env:
+          RELEASE_TAG: ${{ needs.build-check.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.build-check.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          cd release-assets
+          version="${RELEASE_VERSION#v}"
+          base_url="https://github.com/${REPOSITORY}/releases/download/${RELEASE_TAG}"
+
+          mac_arm_file=$(find . -maxdepth 1 -name "rustfs-launcher-macos-aarch64-*.app.tar.gz" ! -name "*-latest*" -print -quit)
+          mac_x64_file=$(find . -maxdepth 1 -name "rustfs-launcher-macos-x86_64-*.app.tar.gz" ! -name "*-latest*" -print -quit)
+          win_file=$(find . -maxdepth 1 -name "rustfs-launcher-windows-x86_64-*-setup.exe" ! -name "*-latest*" -print -quit)
+
+          for file in "$mac_arm_file" "$mac_x64_file" "$win_file"; do
+            if [ -z "$file" ] || [ ! -f "$file.sig" ]; then
+              echo "❌ Missing updater artifact or signature: ${file:-unknown}"
+              exit 1
+            fi
+          done
+
+          jq -n \
+            --arg version "$version" \
+            --arg notes "RustFS Launcher ${version}，包含构建时选定的 RustFS 版本。" \
+            --arg pub_date "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            --arg mac_arm_url "$base_url/$(basename "$mac_arm_file")" \
+            --arg mac_arm_sig "$(cat "$mac_arm_file.sig")" \
+            --arg mac_x64_url "$base_url/$(basename "$mac_x64_file")" \
+            --arg mac_x64_sig "$(cat "$mac_x64_file.sig")" \
+            --arg win_url "$base_url/$(basename "$win_file")" \
+            --arg win_sig "$(cat "$win_file.sig")" \
+            '{
+              version: $version,
+              notes: $notes,
+              pub_date: $pub_date,
+              platforms: {
+                "darwin-aarch64": {url: $mac_arm_url, signature: $mac_arm_sig},
+                "darwin-x86_64": {url: $mac_x64_url, signature: $mac_x64_sig},
+                "windows-x86_64": {url: $win_url, signature: $win_sig}
+              }
+            }' > latest.json
+
+          jq empty latest.json
 
       - name: Upload to GitHub Release
         if: needs.build-check.outputs.is_release == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           workspaces: src-tauri
 
       - name: Install Trunk
-        run: cargo install trunk
+        run: cargo install trunk --version 0.21.14 --locked
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ This ensures the launcher always stays up-to-date with the latest RustFS release
 
 The project uses GitHub Actions for continuous integration and automated releases. See [.github/ACTIONS.md](.github/ACTIONS.md) for details.
 
+Installed launchers can check, download, verify, and install signed application
+updates from the application UI. The update replaces the complete application
+bundle, including the bundled RustFS binary. Release signing and operational
+details are documented in [docs/SELF_UPDATE.md](docs/SELF_UPDATE.md).
+
 For local testing of GitHub Actions workflows, see [.github/TESTING.md](.github/TESTING.md).
 
 ## Recommended IDE Setup

--- a/docs/SELF_UPDATE.md
+++ b/docs/SELF_UPDATE.md
@@ -1,0 +1,72 @@
+# 自升级发布说明
+
+RustFS Launcher 使用 Tauri 2 Updater 进行整包升级。更新包同时包含 Launcher
+和对应平台的 RustFS 二进制文件。
+
+## 版本约定
+
+- Git tag 是 Launcher 版本，必须符合 SemVer，例如 `v0.2.0`。
+- 发布构建会去除 tag 的 `v` 前缀并写入 Tauri 和 Cargo 包版本。
+- 构建时解析到的上游 RustFS 版本通过 `RUSTFS_VERSION` 编译进 Launcher。
+- 手动触发构建时可用 `rustfs_tag` 指定内置版本；未指定时使用 RustFS 最新版。
+
+## 更新签名
+
+Updater 签名与 macOS/Windows 的系统代码签名相互独立，两者都需要配置。
+
+首次配置 Updater 签名：
+
+```bash
+cargo tauri signer generate -w ~/.tauri/rustfs-launcher.key
+```
+
+将生成的公钥内容配置到 `src-tauri/tauri.conf.json` 的
+`plugins.updater.pubkey`。私钥不得提交到仓库，应备份到安全位置，并配置以下
+GitHub Actions Secrets：
+
+- `TAURI_SIGNING_PRIVATE_KEY`：私钥文件内容
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`：私钥密码；无密码时留空
+
+丢失私钥后，已经安装的客户端将无法验证后续版本，因此必须保留离线备份。
+
+## 发布过程
+
+推送版本 tag 后，构建工作流会：
+
+1. 校验并注入 Launcher 版本。
+2. 下载该发布对应的 RustFS 二进制文件。
+3. 构建 macOS Apple Silicon、macOS Intel 和 Windows x86_64 安装包。
+4. 生成 Tauri Updater 产物及 `.sig` 签名。
+5. 汇总全部平台并生成 `latest.json`。
+6. 将安装包、签名和更新清单上传到同一个 GitHub Release。
+
+客户端使用以下固定地址检查更新：
+
+```text
+https://github.com/rustfs/launcher/releases/latest/download/latest.json
+```
+
+必须在所有平台产物生成成功后再发布 `latest.json`，避免客户端获取到不完整
+的版本。
+
+## 用户侧行为
+
+- 用户点击“检查更新”后，Launcher 请求并验证更新清单。
+- 如果由 Launcher 管理的 RustFS 正在运行，安装前会请求用户确认。
+- 用户确认后 RustFS 被停止，更新包下载并通过签名校验，然后安装。
+- 安装成功后 Launcher 自动重启；RustFS 不会自动恢复运行。
+
+用户的数据目录和保存在 WebView 本地存储中的 Launcher 配置不属于应用安装
+包，正常覆盖升级不会主动删除它们。
+
+## 发布前检查
+
+```bash
+cargo fmt --all -- --check
+cargo check -p rustfs-launcher-ui --target wasm32-unknown-unknown
+cargo clippy -p rustfs-launcher --all-targets --all-features -- -D warnings
+cargo test -p rustfs-launcher --all-features
+```
+
+正式对外发布前，还应配置 Apple Developer ID 签名与公证，以及 Windows
+Authenticode 代码签名。

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ regex = "1.10.2"
 tauri-plugin-store = "2.4.1"
 tauri-plugin-window-state = "2.4.1"
 tauri-plugin-single-instance = "2"
+tauri-plugin-updater = "2"
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,15 +1,47 @@
 use crate::config::RustFsConfig;
 use crate::error::{Error, Result};
 use crate::process;
-use crate::state;
+use crate::state::{self, add_app_log};
 use serde::Serialize;
 use std::io::{Error as IoError, ErrorKind};
 use tauri::async_runtime;
+use tauri::{AppHandle, Emitter};
+use tauri_plugin_updater::UpdaterExt;
 
 #[derive(Debug, Serialize)]
 pub struct CommandResponse {
     pub success: bool,
     pub message: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AppVersionInfo {
+    pub launcher_version: String,
+    pub rustfs_version: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdateInfo {
+    pub available: bool,
+    pub current_version: String,
+    pub version: Option<String>,
+    pub notes: Option<String>,
+    pub date: Option<String>,
+    pub rustfs_running: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "event", rename_all = "camelCase")]
+enum UpdateProgress {
+    Started {
+        content_length: Option<u64>,
+    },
+    Progress {
+        chunk_length: usize,
+        downloaded: u64,
+        content_length: Option<u64>,
+    },
+    Finished,
 }
 
 #[tauri::command]
@@ -94,4 +126,93 @@ pub async fn check_tcp_connection(host: String, port: u16) -> Result<bool> {
 #[tauri::command]
 pub async fn is_rustfs_process_running() -> Result<bool> {
     Ok(state::is_rustfs_process_running())
+}
+
+#[tauri::command]
+pub fn get_app_version_info(app: AppHandle) -> AppVersionInfo {
+    AppVersionInfo {
+        launcher_version: app.package_info().version.to_string(),
+        rustfs_version: option_env!("RUSTFS_VERSION")
+            .unwrap_or("unknown")
+            .to_string(),
+    }
+}
+
+#[tauri::command]
+pub async fn check_for_update(app: AppHandle) -> Result<UpdateInfo> {
+    let current_version = app.package_info().version.to_string();
+    let update = app
+        .updater()
+        .map_err(|error| Error::Update(error.to_string()))?
+        .check()
+        .await
+        .map_err(|error| Error::Update(error.to_string()))?;
+
+    Ok(match update {
+        Some(update) => UpdateInfo {
+            available: true,
+            current_version,
+            version: Some(update.version),
+            notes: update.body,
+            date: update.date.map(|date| date.to_string()),
+            rustfs_running: state::is_rustfs_process_running(),
+        },
+        None => UpdateInfo {
+            available: false,
+            current_version,
+            version: None,
+            notes: None,
+            date: None,
+            rustfs_running: state::is_rustfs_process_running(),
+        },
+    })
+}
+
+#[tauri::command]
+pub async fn install_update(app: AppHandle) -> Result<CommandResponse> {
+    let update = app
+        .updater()
+        .map_err(|error| Error::Update(error.to_string()))?
+        .check()
+        .await
+        .map_err(|error| Error::Update(error.to_string()))?
+        .ok_or_else(|| Error::Update("No update is available".to_string()))?;
+
+    if state::is_rustfs_process_running() {
+        add_app_log("Stopping RustFS before installing update".to_string());
+        state::terminate_rustfs_process();
+    }
+
+    let progress_app = app.clone();
+    let finished_app = app.clone();
+    let mut downloaded = 0_u64;
+
+    update
+        .download_and_install(
+            move |chunk_length, content_length| {
+                if downloaded == 0 {
+                    let _ = progress_app.emit(
+                        "update-progress",
+                        UpdateProgress::Started { content_length },
+                    );
+                }
+                downloaded += chunk_length as u64;
+                let _ = progress_app.emit(
+                    "update-progress",
+                    UpdateProgress::Progress {
+                        chunk_length,
+                        downloaded,
+                        content_length,
+                    },
+                );
+            },
+            move || {
+                let _ = finished_app.emit("update-progress", UpdateProgress::Finished);
+            },
+        )
+        .await
+        .map_err(|error| Error::Update(error.to_string()))?;
+
+    add_app_log("Update installed; restarting launcher".to_string());
+    app.restart();
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -25,6 +25,9 @@ pub enum Error {
 
     #[error("RustFS binary failed with exit code: {0}")]
     BinaryFailed(String),
+
+    #[error("Update failed: {0}")]
+    Update(String),
 }
 
 impl Serialize for Error {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_single_instance::init(
@@ -101,7 +102,10 @@ pub fn run() {
             commands::get_rustfs_logs,
             commands::diagnose_rustfs_binary,
             commands::check_tcp_connection,
-            commands::is_rustfs_process_running
+            commands::is_rustfs_process_running,
+            commands::get_app_version_info,
+            commands::check_for_update,
+            commands::install_update
         ])
         .build(tauri::generate_context!())
         .expect("error building tauri application")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,7 +49,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDNGODI0RTNDNzJEQzAyMjYKUldRbUF0eHlQRTZDUDl0V2FqNkk1Wm5SakpIMkRwWFJ6RW9RdWZmem1Zbmx4QjBkL28rcWoxYUcK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEJCOEZBMjlBRUZGMzNENjkKUldScFBmUHZtcUtQdTdPVDJFYitWQlR1NW1tWlJqV3RZNHErb21sMC9tVXVJRkJqMUtMaUpsY2cK",
       "endpoints": [
         "https://github.com/rustfs/launcher/releases/latest/download/latest.json"
       ],

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,6 +35,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -45,5 +46,16 @@
     "resources": [
       "binaries/*"
     ]
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDNGODI0RTNDNzJEQzAyMjYKUldRbUF0eHlQRTZDUDl0V2FqNkk1Wm5SakpIMkRwWFJ6RW9RdWZmem1Zbmx4QjBkL28rcWoxYUcK",
+      "endpoints": [
+        "https://github.com/rustfs/launcher/releases/latest/download/latest.json"
+      ],
+      "windows": {
+        "installMode": "passive"
+      }
+    }
   }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use crate::components::config_form::ConfigForm;
 use crate::components::log_viewer::LogViewer;
 use crate::components::toast::{Toast, ToastMessage, ToastType};
-use crate::types::{CommandResponse, LogEntry, LogType, RustFsConfig};
+use crate::types::{AppVersionInfo, CommandResponse, LogEntry, LogType, RustFsConfig, UpdateInfo};
 use leptos::ev::SubmitEvent;
 use leptos::prelude::*;
 use std::collections::VecDeque;
@@ -175,6 +175,11 @@ pub fn App() -> impl IntoView {
     let (current_log_type, set_current_log_type) = signal(LogType::App);
     let (service_status, set_service_status) = signal(false);
     let (can_stop, set_can_stop) = signal(false);
+    let (version_info, set_version_info) = signal(None::<AppVersionInfo>);
+    let (update_info, set_update_info) = signal(None::<UpdateInfo>);
+    let (is_checking_update, set_is_checking_update) = signal(false);
+    let (is_installing_update, set_is_installing_update) = signal(false);
+    let (update_progress, set_update_progress) = signal(None::<u32>);
 
     let remove_toast = Callback::new(move |id: u64| {
         set_toasts.update(|current| {
@@ -239,6 +244,12 @@ pub fn App() -> impl IntoView {
             return;
         }
 
+        let version_value =
+            tauri_invoke("get_app_version_info", js_sys::Object::new().into()).await;
+        if let Ok(info) = serde_wasm_bindgen::from_value::<AppVersionInfo>(version_value) {
+            set_version_info.set(Some(info));
+        }
+
         push_log(
             app_log_writer,
             "[DEBUG] Setting up real-time log listeners...".to_string(),
@@ -289,6 +300,35 @@ pub fn App() -> impl IntoView {
         if let Some(window) = web_sys::window() {
             let app_listener = create_log_listener(app_log_writer, APP_LOG_CAPACITY);
             let rustfs_listener = create_log_listener(rustfs_log_writer, RUSTFS_LOG_CAPACITY);
+            let update_listener = Closure::wrap(Box::new(move |event: JsValue| {
+                let Ok(payload) = js_sys::Reflect::get(&event, &"payload".into()) else {
+                    return;
+                };
+                let event_name = js_sys::Reflect::get(&payload, &"event".into())
+                    .ok()
+                    .and_then(|value| value.as_string());
+
+                match event_name.as_deref() {
+                    Some("started") => set_update_progress.set(Some(0)),
+                    Some("progress") => {
+                        let downloaded = js_sys::Reflect::get(&payload, &"downloaded".into())
+                            .ok()
+                            .and_then(|value| value.as_f64());
+                        if let Some(downloaded) = downloaded {
+                            let percent = js_sys::Reflect::get(&payload, &"content_length".into())
+                                .ok()
+                                .and_then(|value| value.as_f64())
+                                .filter(|total| *total > 0.0)
+                                .map(|total| ((downloaded / total) * 100.0).min(100.0) as u32);
+                            if percent.is_some() {
+                                set_update_progress.set(percent);
+                            }
+                        }
+                    }
+                    Some("finished") => set_update_progress.set(Some(100)),
+                    _ => {}
+                }
+            }) as Box<dyn FnMut(JsValue)>);
 
             if let Ok(tauri) = js_sys::Reflect::get(&window, &"__TAURI__".into()) {
                 if let Ok(event) = js_sys::Reflect::get(&tauri, &"event".into()) {
@@ -310,6 +350,11 @@ pub fn App() -> impl IntoView {
                             &RUSTFS_EXIT_EVENT.into(),
                             exit_listener.as_ref().unchecked_ref(),
                         );
+                        let _ = listen_fn.call2(
+                            &event,
+                            &"update-progress".into(),
+                            update_listener.as_ref().unchecked_ref(),
+                        );
                     }
                 }
             }
@@ -317,6 +362,7 @@ pub fn App() -> impl IntoView {
             app_listener.forget();
             rustfs_listener.forget();
             exit_listener.forget();
+            update_listener.forget();
         }
 
         // Fetch initial logs
@@ -489,6 +535,76 @@ pub fn App() -> impl IntoView {
         });
     };
 
+    let check_update = move |_| {
+        if !is_tauri() || is_checking_update.get_untracked() || is_installing_update.get_untracked()
+        {
+            return;
+        }
+
+        set_is_checking_update.set(true);
+        set_update_info.set(None);
+        spawn_local(async move {
+            let result = tauri_invoke("check_for_update", js_sys::Object::new().into()).await;
+            match serde_wasm_bindgen::from_value::<UpdateInfo>(result) {
+                Ok(info) => {
+                    if info.available {
+                        show_toast(
+                            format!(
+                                "发现新版本 {}",
+                                info.version.as_deref().unwrap_or("unknown")
+                            ),
+                            ToastType::Success,
+                        );
+                    } else {
+                        show_toast("当前已是最新版本".to_string(), ToastType::Success);
+                    }
+                    set_update_info.set(Some(info));
+                }
+                Err(_) => {
+                    show_toast("检查更新失败，请查看应用日志".to_string(), ToastType::Error);
+                }
+            }
+            set_is_checking_update.set(false);
+        });
+    };
+
+    let install_update = move |_| {
+        if is_installing_update.get_untracked() {
+            return;
+        }
+
+        let rustfs_running = update_info
+            .get_untracked()
+            .map(|info| info.rustfs_running)
+            .unwrap_or(false);
+        if rustfs_running {
+            let confirmed = web_sys::window()
+                .and_then(|window| {
+                    window
+                        .confirm_with_message(
+                            "更新会停止当前由 Launcher 管理的 RustFS 服务，并在安装后重启 Launcher。是否继续？",
+                        )
+                        .ok()
+                })
+                .unwrap_or(false);
+            if !confirmed {
+                return;
+            }
+        }
+
+        set_is_installing_update.set(true);
+        set_update_progress.set(Some(0));
+        show_toast("正在下载并安装更新…".to_string(), ToastType::Info);
+        spawn_local(async move {
+            let result = tauri_invoke("install_update", js_sys::Object::new().into()).await;
+            if serde_wasm_bindgen::from_value::<CommandResponse>(result).is_err() {
+                set_is_installing_update.set(false);
+                set_update_progress.set(None);
+                show_toast("更新安装失败，请查看应用日志".to_string(), ToastType::Error);
+            }
+        });
+    };
+
     view! {
         <style>{LOGS_CSS}</style>
         <main class="container">
@@ -539,6 +655,68 @@ pub fn App() -> impl IntoView {
                         <strong>{move || if is_running.get() { "Locked" } else { "Editable" }}</strong>
                     </div>
                 </div>
+
+                <section class="update-card">
+                    <div class="update-heading">
+                        <div>
+                            <span class="summary-label">"Software Update"</span>
+                            <strong>"版本与更新"</strong>
+                        </div>
+                        <button
+                            type="button"
+                            class="update-check-btn"
+                            disabled=move || is_checking_update.get() || is_installing_update.get()
+                            on:click=check_update
+                        >
+                            {move || if is_checking_update.get() { "检查中…" } else { "检查更新" }}
+                        </button>
+                    </div>
+
+                    <div class="version-row">
+                        <span>{move || format!(
+                            "Launcher {}",
+                            version_info.get().map(|info| info.launcher_version).unwrap_or_else(|| "—".to_string())
+                        )}</span>
+                        <span>{move || format!(
+                            "RustFS {}",
+                            version_info.get().map(|info| info.rustfs_version).unwrap_or_else(|| "—".to_string())
+                        )}</span>
+                    </div>
+
+                    {move || update_info.get().map(|info| {
+                        if info.available {
+                            let version = info.version.unwrap_or_else(|| "unknown".to_string());
+                            let notes = info.notes.unwrap_or_else(|| "此版本没有更新说明。".to_string());
+                            view! {
+                                <div class="update-available">
+                                    <div>
+                                        <strong>{format!("可更新至 {}", version)}</strong>
+                                        <p>{notes}</p>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        class="update-install-btn"
+                                        disabled=move || is_installing_update.get()
+                                        on:click=install_update
+                                    >
+                                        {move || if is_installing_update.get() { "安装中…" } else { "立即更新" }}
+                                    </button>
+                                </div>
+                            }.into_any()
+                        } else {
+                            view! { <p class="update-current">"当前已是最新版本。"</p> }.into_any()
+                        }
+                    })}
+
+                    {move || is_installing_update.get().then(|| view! {
+                        <div class="update-progress">
+                            <div
+                                class="update-progress-bar"
+                                style:width=move || format!("{}%", update_progress.get().unwrap_or(8))
+                            ></div>
+                        </div>
+                    })}
+                </section>
 
                 <ConfigForm
                     config=config

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,3 +42,19 @@ pub struct CommandResponse {
     pub success: bool,
     pub message: String,
 }
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct AppVersionInfo {
+    pub launcher_version: String,
+    pub rustfs_version: String,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct UpdateInfo {
+    pub available: bool,
+    pub current_version: String,
+    pub version: Option<String>,
+    pub notes: Option<String>,
+    pub date: Option<String>,
+    pub rustfs_running: bool,
+}

--- a/styles.css
+++ b/styles.css
@@ -216,6 +216,88 @@ input {
   font-weight: 700;
 }
 
+.update-card {
+  padding: 16px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: var(--shadow-lg);
+}
+
+.update-heading,
+.update-available,
+.version-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.update-heading strong {
+  display: block;
+  margin-top: 5px;
+}
+
+.version-row {
+  justify-content: flex-start;
+  margin-top: 12px;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.update-check-btn,
+.update-install-btn {
+  padding: 8px 12px;
+  border: 1px solid rgba(37, 99, 255, 0.24);
+  border-radius: 12px;
+  background: var(--brand-blue-soft);
+  color: var(--brand-blue-strong);
+  font-weight: 700;
+}
+
+.update-install-btn {
+  flex-shrink: 0;
+  border: none;
+  background: var(--brand-blue);
+  color: #fff;
+}
+
+.update-check-btn:hover:not(:disabled),
+.update-install-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.update-available {
+  align-items: flex-start;
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-color);
+}
+
+.update-available p,
+.update-current {
+  margin: 5px 0 0;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.update-progress {
+  height: 5px;
+  margin-top: 14px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--brand-blue-soft);
+}
+
+.update-progress-bar {
+  height: 100%;
+  min-width: 8%;
+  border-radius: inherit;
+  background: var(--brand-blue);
+  transition: width 0.2s ease;
+}
+
 .config-form {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- Integrate the Tauri 2 Updater for update checks, downloads, signature verification, installation, and application restart.
- Prompt for confirmation and stop the RustFS process managed by the launcher before installing an update.
- Display the Launcher and bundled RustFS versions, release notes, and download progress in the Leptos UI.
- Keep the Launcher version independent from the RustFS version selected at build time.
- Update GitHub Actions to generate macOS and Windows updater artifacts, `.sig` files, and `latest.json`.
- Add documentation for self-update releases and signing-key management.
- Pin Trunk to `0.21.14` with locked dependencies in CI and Windows release builds.

## User impact

Users can check for and install complete application updates directly from the launcher. An update replaces both the Launcher and the bundled RustFS binary. After a successful installation, the Launcher restarts automatically, but RustFS is not started again automatically.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p rustfs-launcher-ui --target wasm32-unknown-unknown`
- `cargo clippy -p rustfs-launcher --all-targets --all-features -- -D warnings`
- `cargo test -p rustfs-launcher --all-features`
- `cargo check -p rustfs-launcher`
- GitHub Actions workflow YAML validation
- `git diff --check`
- PR CI workflow passed successfully

## Release configuration

@overtrue, please help configure and verify the following release requirements:

- Add `TAURI_SIGNING_PRIVATE_KEY` to the repository's GitHub Actions secrets.
- Add `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`; it may remain empty for the currently generated passwordless key, but the production key-management policy should be confirmed.
- Configure macOS Developer ID signing and Apple notarization.
- Configure Windows Authenticode code signing.
- After the first release, verify that the GitHub Release contains `latest.json`, updater artifacts for every supported platform, and their corresponding `.sig` files.

See `docs/SELF_UPDATE.md` for detailed release instructions.