### PR TITLE
feat: add manual RustFS updates and keep launch on Windows/macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,9 @@ jobs:
         run: trunk build
 
       - name: Run tests
-        run: cargo test -p rustfs-launcher --all-features --locked
+        run: |
+          cargo test -p rustfs-launcher --all-features --locked
+          cargo test -p rustfs-launcher-ui --locked
 
   test-native:
     name: Native tests (${{ matrix.os }})

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +540,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -554,6 +579,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +607,15 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -689,6 +740,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -710,7 +771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -723,7 +784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -732,6 +793,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1291,6 +1361,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1340,6 +1411,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1558,8 +1635,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1581,8 +1660,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1774,6 +1856,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1995,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1937,9 +2039,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2321,6 +2425,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,6 +2706,12 @@ name = "log"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "manyhow"
@@ -3039,16 +3159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,6 +3557,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,6 +3655,32 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -3621,8 +3814,10 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3631,8 +3826,10 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -3729,19 +3926,21 @@ dependencies = [
  "libc",
  "log",
  "regex",
+ "reqwest",
+ "semver",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
- "tauri-plugin-shell",
  "tauri-plugin-single-instance",
- "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tempfile",
  "thiserror 2.0.20",
+ "zip",
 ]
 
 [[package]]
@@ -3778,6 +3977,7 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3804,6 +4004,7 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3813,7 +4014,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -3840,6 +4041,7 @@ version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3933,7 +4135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4229,19 +4431,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
-]
-
-[[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "sigchld",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4249,27 +4440,6 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "sigchld"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
-dependencies = [
- "libc",
- "os_pipe",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4506,6 +4676,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4560,7 +4751,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -4814,27 +5005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-shell"
-version = "2.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
-dependencies = [
- "encoding_rs",
- "log",
- "open",
- "os_pipe",
- "regex",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "shared_child",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.20",
- "tokio",
-]
-
-[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4848,22 +5018,6 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
-]
-
-[[package]]
-name = "tauri-plugin-store"
-version = "2.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6708afbe549f176b712066e71648ba8fafba20789453718260c7ca356733cb0c"
-dependencies = [
- "dunce",
- "serde",
- "serde_json",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.20",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -5151,19 +5305,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.4",
 ]
 
 [[package]]
@@ -5185,6 +5327,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -5728,6 +5871,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5975,6 +6128,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6556,15 +6720,35 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
+ "flate2",
  "indexmap 2.14.0",
  "memchr",
+ "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ check-test:
 	@echo "🧪 Running tests..."
 	@echo "=========================================="
 	@cargo test -p rustfs-launcher --all-features
+	@cargo test -p rustfs-launcher-ui
 	@echo "✅ All tests passed!"
 	@echo ""
 

--- a/README.md
+++ b/README.md
@@ -168,12 +168,21 @@ files instead, so this tab is often quiet. Auto-scroll follows new lines; Clear 
 | Server logs | A `logs` folder next to the data folder |
 | Launcher settings | Stored by the app itself; no file for you to edit |
 | The app | `%LOCALAPPDATA%\RustFS Launcher` on Windows, `/Applications` on macOS |
+| Updated RustFS binary | App data: `%APPDATA%\com.dandan.rustfs-launcher\binaries` on Windows, `~/Library/Application Support/com.dandan.rustfs-launcher/binaries` on macOS |
 
 ## Updating
 
-Press **Check for Updates** in the Version & Updates card. If a newer release exists, the launcher downloads
-it, verifies its signature, and installs it. If RustFS is running, the launcher asks first, then stops the
-server before restarting itself. Updates replace the whole app, including the bundled RustFS server.
+The Version & Updates card covers **two independent updates**, both started by **Check for Updates**
+(Windows and macOS only):
+
+1. **Launcher** — a signed whole-app update. This replaces the launcher and the bundled RustFS, then restarts
+   the app.
+2. **RustFS** — a verified binary-only update from the upstream RustFS release feed. The archive is checked
+   against `SHA256SUMS`, smoke-tested, and installed into the launcher data directory. You do not need a new
+   launcher installer just to pick up a newer RustFS.
+
+If RustFS is running, the launcher asks before stopping it. RustFS is not started again automatically after
+either update.
 
 The signing and release mechanics are documented in [docs/SELF_UPDATE.md](docs/SELF_UPDATE.md).
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -154,11 +154,17 @@ Clear 会清空两个页签。
 | 服务端日志 | 数据文件夹同级的 `logs` 文件夹 |
 | 启动器的设置 | 由程序自己保存，没有需要手动编辑的文件 |
 | 程序本体 | Windows 在 `%LOCALAPPDATA%\RustFS Launcher`，macOS 在 `/Applications` |
+| 手动升级后的 RustFS 二进制 | Windows：`%APPDATA%\com.dandan.rustfs-launcher\binaries`；macOS：`~/Library/Application Support/com.dandan.rustfs-launcher/binaries` |
 
 ## 升级
 
-在 Version & Updates 卡片里点 **Check for Updates**。如果有新版本，启动器会下载、校验签名并安装。若 RustFS
-正在运行，它会先征求你的同意，停掉服务后再重启自己。升级会整体替换程序，包括内置的 RustFS 服务端。
+Version & Updates 卡片负责 **两类互相独立的升级**，都通过 **Check for Updates** 触发（仅 Windows 和 macOS）：
+
+1. **Launcher** — 带签名的整包升级，会替换启动器以及内置的 RustFS，然后重启程序。
+2. **RustFS** — 只更新服务端二进制。启动器从上游发布源下载对应平台的压缩包，用 `SHA256SUMS` 校验，再做一次
+   `--version` 冒烟测试，最后写入启动器数据目录。不必为了新的 RustFS 去重装启动器。
+
+若 RustFS 正在运行，升级前会征求确认并先停掉服务。升级完成后不会自动再把它拉起来。
 
 签名与发布的细节见 [docs/SELF_UPDATE.md](docs/SELF_UPDATE.md)。
 

--- a/build.sh
+++ b/build.sh
@@ -88,8 +88,9 @@ case "$OS" in
         esac
         ;;
     "Linux")
-        echo "✗ Error: Linux platform not supported yet"
-        echo "Please download the appropriate binary manually to $BINARIES_DIR/"
+        echo "✗ Error: Linux is not a supported launcher target"
+        echo "RustFS Launcher ships Windows and macOS installers only."
+        echo "On Linux, run the RustFS binary from https://github.com/rustfs/rustfs/releases"
         exit 1
         ;;
     *)

--- a/docs/SELF_UPDATE.md
+++ b/docs/SELF_UPDATE.md
@@ -1,7 +1,11 @@
 # 自升级发布说明
 
-RustFS Launcher 使用 Tauri 2 Updater 进行整包升级。更新包同时包含 Launcher
-和对应平台的 RustFS 二进制文件。
+RustFS Launcher 支持两条独立的升级路径，均面向 **Windows 和 macOS**：
+
+- **Launcher 整包升级**：Tauri 2 Updater，更新包同时包含 Launcher 和对应平台的 RustFS 二进制。
+- **RustFS 二进制升级**：用户可在启动器内手动检查并安装上游 `rustfs/rustfs` 的新版本，无需重装启动器。
+
+Linux 不是发布目标。启动器在 Linux 上会拒绝解析平台二进制，并提示仅支持 Windows 与 macOS。
 
 ## 版本约定
 
@@ -51,10 +55,24 @@ https://github.com/rustfs/launcher/releases/latest/download/latest.json
 
 ## 用户侧行为
 
-- 用户点击“检查更新”后，Launcher 请求并验证更新清单。
+启动时会静默检查一次更新；用户也可随时点击“Check for Updates”。检查会同时请求：
+
+- Launcher 更新清单（签名校验）
+- 上游 `https://version.rustfs.com/latest.json`（RustFS 版本）
+
+### Launcher 整包
+
 - 如果由 Launcher 管理的 RustFS 正在运行，安装前会请求用户确认。
 - 用户确认后 RustFS 被停止，更新包下载并通过签名校验，然后安装。
 - 安装成功后 Launcher 自动重启；RustFS 不会自动恢复运行。
+
+### RustFS 二进制
+
+- 仅下载当前平台的上游 zip（macOS aarch64 / macOS x86_64 / Windows x86_64）。
+- 用同一 Release 中的 `SHA256SUMS` 校验压缩包。
+- 解压后对二进制执行 `--version`；失败则中止，不覆盖现有文件。
+- 安装到启动器数据目录下的 `binaries/`，并写入 `installed.json`。
+- 若启动器随后通过整包升级内置了更新的 RustFS，内置版本优先。
 
 用户的数据目录和保存在 WebView 本地存储中的 Launcher 配置不属于应用安装
 包，正常覆盖升级不会主动删除它们。

--- a/docs/SELF_UPDATE.md
+++ b/docs/SELF_UPDATE.md
@@ -69,6 +69,7 @@ https://github.com/rustfs/launcher/releases/latest/download/latest.json
 ### RustFS 二进制
 
 - 仅下载当前平台的上游 zip（macOS aarch64 / macOS x86_64 / Windows x86_64）。
+- 检查更新时会读取同一 Release 的 `SHA256SUMS`。若最新版本没有该平台的资源，界面显示原因而不是“可更新”。
 - 用同一 Release 中的 `SHA256SUMS` 校验压缩包。
 - 解压后对二进制执行 `--version`；失败则中止，不覆盖现有文件。
 - 安装到启动器数据目录下的 `binaries/`，并写入 `installed.json`。
@@ -84,6 +85,7 @@ cargo fmt --all -- --check
 cargo check -p rustfs-launcher-ui --target wasm32-unknown-unknown
 cargo clippy -p rustfs-launcher --all-targets --all-features -- -D warnings
 cargo test -p rustfs-launcher --all-features
+cargo test -p rustfs-launcher-ui
 ```
 
 正式对外发布前，还应配置 Apple Developer ID 签名与公证，以及 Windows

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>RustFS Launcher</title>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,7 +24,6 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "^2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
-tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -33,7 +32,16 @@ env_logger = "0.11.8"
 chrono = { version = "0.4.41", features = ["serde"] }
 thiserror = "2.0.12"
 regex = "1.10.2"
-tauri-plugin-store = "2.4.1"
+semver = "1.0.28"
+sha2 = "0.10.9"
+zip = { version = "4.6.1", default-features = false, features = ["deflate"] }
+reqwest = { version = "0.13.4", default-features = false, features = [
+  "charset",
+  "http2",
+  "json",
+  "rustls",
+  "system-proxy",
+] }
 tauri-plugin-window-state = "2.4.1"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"

--- a/src-tauri/src/binaries.rs
+++ b/src-tauri/src/binaries.rs
@@ -1,0 +1,131 @@
+//! Bookkeeping for the RustFS binary the launcher runs.
+//!
+//! Two copies can exist: the one bundled into the installer (read-only, inside
+//! the app bundle or `resources/`) and one the user installed later through the
+//! in-app RustFS update flow (writable, under the app data directory).
+
+use crate::error::{Error, Result};
+use crate::platform::Platform;
+use crate::state::{acquire, APP_HANDLE};
+use crate::version;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tauri::Manager;
+
+const RECORD_FILE: &str = "installed.json";
+
+/// Metadata written next to a user-installed RustFS binary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstalledRecord {
+    pub version: String,
+    pub binary: String,
+    pub asset: String,
+    pub sha256: String,
+    pub installed_at: String,
+}
+
+/// Version compiled into the launcher by the release workflow.
+pub fn bundled_version() -> Option<&'static str> {
+    option_env!("RUSTFS_VERSION")
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != "unknown")
+}
+
+/// Writable directory holding user-installed RustFS binaries.
+pub fn managed_dir() -> Option<PathBuf> {
+    let handle = acquire(&APP_HANDLE);
+    handle
+        .as_ref()
+        .and_then(|app| app.path().app_data_dir().ok())
+        .map(|dir| dir.join("binaries"))
+}
+
+pub fn ensure_managed_dir() -> Result<PathBuf> {
+    let dir = managed_dir().ok_or_else(|| {
+        Error::RustFsUpdate("Unable to resolve the launcher data directory".to_string())
+    })?;
+    std::fs::create_dir_all(&dir).map_err(Error::Io)?;
+    Ok(dir)
+}
+
+pub fn read_record_from(dir: &Path) -> Option<InstalledRecord> {
+    let contents = std::fs::read_to_string(dir.join(RECORD_FILE)).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+pub fn write_record(dir: &Path, record: &InstalledRecord) -> Result<()> {
+    let contents = serde_json::to_string_pretty(record)
+        .map_err(|error| Error::RustFsUpdate(error.to_string()))?;
+    std::fs::write(dir.join(RECORD_FILE), contents).map_err(Error::Io)
+}
+
+/// User-installed binary to run, when it exists and is not older than the
+/// bundled copy.
+pub fn installed_binary() -> Option<(PathBuf, InstalledRecord)> {
+    let dir = managed_dir()?;
+    let record = read_record_from(&dir)?;
+    if !version::prefer_installed(&record.version, bundled_version()) {
+        return None;
+    }
+
+    let path = dir.join(&record.binary);
+    path.is_file().then_some((path, record))
+}
+
+/// Version of RustFS the launcher will actually start.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveVersion {
+    pub version: String,
+    pub managed: bool,
+}
+
+pub fn effective_version() -> EffectiveVersion {
+    match installed_binary() {
+        Some((_, record)) => EffectiveVersion {
+            version: record.version,
+            managed: true,
+        },
+        None => EffectiveVersion {
+            version: bundled_version().unwrap_or("unknown").to_string(),
+            managed: false,
+        },
+    }
+}
+
+/// File name the platform expects, e.g. `rustfs-windows-x86_64.exe`.
+pub fn binary_name() -> Result<&'static str> {
+    Platform::detect().map(Platform::binary_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{read_record_from, write_record, InstalledRecord};
+
+    #[test]
+    fn record_round_trips_through_the_managed_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = InstalledRecord {
+            version: "1.0.0-rc.4".to_string(),
+            binary: "rustfs-macos-aarch64".to_string(),
+            asset: "rustfs-macos-aarch64-v1.0.0-rc.4.zip".to_string(),
+            sha256: "6c6a0e84".to_string(),
+            installed_at: "2026-08-28T00:00:00Z".to_string(),
+        };
+
+        write_record(dir.path(), &record).unwrap();
+        let loaded = read_record_from(dir.path()).expect("record should be readable");
+
+        assert_eq!(loaded.version, record.version);
+        assert_eq!(loaded.binary, record.binary);
+        assert_eq!(loaded.sha256, record.sha256);
+    }
+
+    #[test]
+    fn missing_or_corrupt_records_are_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read_record_from(dir.path()).is_none());
+
+        std::fs::write(dir.path().join("installed.json"), "not json").unwrap();
+        assert!(read_record_from(dir.path()).is_none());
+    }
+}

--- a/src-tauri/src/binaries.rs
+++ b/src-tauri/src/binaries.rs
@@ -56,20 +56,29 @@ pub fn read_record_from(dir: &Path) -> Option<InstalledRecord> {
 pub fn write_record(dir: &Path, record: &InstalledRecord) -> Result<()> {
     let contents = serde_json::to_string_pretty(record)
         .map_err(|error| Error::RustFsUpdate(error.to_string()))?;
-    std::fs::write(dir.join(RECORD_FILE), contents).map_err(Error::Io)
+    let dest = dir.join(RECORD_FILE);
+    let tmp = dir.join(format!("{RECORD_FILE}.tmp"));
+    std::fs::write(&tmp, contents).map_err(Error::Io)?;
+    std::fs::rename(&tmp, dest).map_err(Error::Io)
 }
 
 /// User-installed binary to run, when it exists and is not older than the
 /// bundled copy.
-pub fn installed_binary() -> Option<(PathBuf, InstalledRecord)> {
-    let dir = managed_dir()?;
-    let record = read_record_from(&dir)?;
-    if !version::prefer_installed(&record.version, bundled_version()) {
+pub fn installed_binary_from(
+    dir: &Path,
+    bundled: Option<&str>,
+) -> Option<(PathBuf, InstalledRecord)> {
+    let record = read_record_from(dir)?;
+    if !version::prefer_installed(&record.version, bundled) {
         return None;
     }
 
     let path = dir.join(&record.binary);
     path.is_file().then_some((path, record))
+}
+
+pub fn installed_binary() -> Option<(PathBuf, InstalledRecord)> {
+    installed_binary_from(&managed_dir()?, bundled_version())
 }
 
 /// Version of RustFS the launcher will actually start.
@@ -79,17 +88,21 @@ pub struct EffectiveVersion {
     pub managed: bool,
 }
 
-pub fn effective_version() -> EffectiveVersion {
-    match installed_binary() {
+pub fn effective_version_from(dir: Option<&Path>, bundled: Option<&str>) -> EffectiveVersion {
+    match dir.and_then(|dir| installed_binary_from(dir, bundled)) {
         Some((_, record)) => EffectiveVersion {
             version: record.version,
             managed: true,
         },
         None => EffectiveVersion {
-            version: bundled_version().unwrap_or("unknown").to_string(),
+            version: bundled.unwrap_or("unknown").to_string(),
             managed: false,
         },
     }
+}
+
+pub fn effective_version() -> EffectiveVersion {
+    effective_version_from(managed_dir().as_deref(), bundled_version())
 }
 
 /// File name the platform expects, e.g. `rustfs-windows-x86_64.exe`.
@@ -99,7 +112,20 @@ pub fn binary_name() -> Result<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use super::{read_record_from, write_record, InstalledRecord};
+    use super::{
+        effective_version_from, installed_binary_from, read_record_from, write_record,
+        InstalledRecord,
+    };
+
+    fn sample_record(version: &str, binary: &str) -> InstalledRecord {
+        InstalledRecord {
+            version: version.to_string(),
+            binary: binary.to_string(),
+            asset: format!("{binary}-v{version}.zip"),
+            sha256: "6c6a0e84".to_string(),
+            installed_at: "2026-08-28T00:00:00Z".to_string(),
+        }
+    }
 
     #[test]
     fn record_round_trips_through_the_managed_dir() {
@@ -127,5 +153,52 @@ mod tests {
 
         std::fs::write(dir.path().join("installed.json"), "not json").unwrap();
         assert!(read_record_from(dir.path()).is_none());
+    }
+
+    #[test]
+    fn installed_binary_requires_the_file_and_a_new_enough_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = sample_record("1.0.0-rc.4", "rustfs-macos-aarch64");
+        write_record(dir.path(), &record).unwrap();
+
+        assert!(
+            installed_binary_from(dir.path(), Some("1.0.0-rc.3")).is_none(),
+            "record without the binary file must be ignored"
+        );
+
+        std::fs::write(dir.path().join(&record.binary), b"stub").unwrap();
+        let (path, loaded) =
+            installed_binary_from(dir.path(), Some("1.0.0-rc.3")).expect("newer install wins");
+        assert_eq!(loaded.version, "1.0.0-rc.4");
+        assert_eq!(path.file_name().unwrap(), "rustfs-macos-aarch64");
+
+        assert!(
+            installed_binary_from(dir.path(), Some("1.0.0-rc.5")).is_none(),
+            "an older install must not shadow a newer bundle"
+        );
+        assert!(installed_binary_from(dir.path(), None).is_some());
+    }
+
+    #[test]
+    fn effective_version_prefers_the_install_that_will_actually_run() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            effective_version_from(None, Some("1.0.0-rc.3")).version,
+            "1.0.0-rc.3"
+        );
+        assert!(!effective_version_from(None, Some("1.0.0-rc.3")).managed);
+        assert_eq!(effective_version_from(None, None).version, "unknown");
+
+        let record = sample_record("1.0.0-rc.4", "rustfs-windows-x86_64.exe");
+        write_record(dir.path(), &record).unwrap();
+        std::fs::write(dir.path().join(&record.binary), b"stub").unwrap();
+
+        let managed = effective_version_from(Some(dir.path()), Some("1.0.0-rc.3"));
+        assert_eq!(managed.version, "1.0.0-rc.4");
+        assert!(managed.managed);
+
+        let bundled = effective_version_from(Some(dir.path()), Some("1.0.0"));
+        assert_eq!(bundled.version, "1.0.0");
+        assert!(!bundled.managed);
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -190,28 +190,45 @@ pub async fn check_for_update(app: AppHandle) -> Result<UpdateInfo> {
     let current_version = app.package_info().version.to_string();
     let update = app
         .updater()
-        .map_err(|error| Error::Update(error.to_string()))?
+        .map_err(|error| {
+            add_app_log(format!("Launcher update check failed: {error}"));
+            Error::Update(error.to_string())
+        })?
         .check()
         .await
-        .map_err(|error| Error::Update(error.to_string()))?;
+        .map_err(|error| {
+            add_app_log(format!("Launcher update check failed: {error}"));
+            Error::Update(error.to_string())
+        })?;
 
     Ok(match update {
-        Some(update) => UpdateInfo {
-            available: true,
-            current_version,
-            version: Some(update.version),
-            notes: update.body,
-            date: update.date.map(|date| date.to_string()),
-            rustfs_running: state::is_rustfs_process_running(),
-        },
-        None => UpdateInfo {
-            available: false,
-            current_version,
-            version: None,
-            notes: None,
-            date: None,
-            rustfs_running: state::is_rustfs_process_running(),
-        },
+        Some(update) => {
+            add_app_log(format!(
+                "Launcher update available: {current_version} -> {}",
+                update.version
+            ));
+            UpdateInfo {
+                available: true,
+                current_version,
+                version: Some(update.version),
+                notes: update.body,
+                date: update.date.map(|date| date.to_string()),
+                rustfs_running: state::is_rustfs_process_running(),
+            }
+        }
+        None => {
+            add_app_log(format!(
+                "Launcher {current_version} is already the latest release"
+            ));
+            UpdateInfo {
+                available: false,
+                current_version,
+                version: None,
+                notes: None,
+                date: None,
+                rustfs_running: state::is_rustfs_process_running(),
+            }
+        }
     })
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,6 +1,9 @@
+use crate::binaries;
 use crate::config::RustFsConfig;
 use crate::error::{Error, Result};
+use crate::platform;
 use crate::process;
+use crate::rustfs_update::{self, RustFsUpdateInfo};
 use crate::state::{self, add_app_log};
 use serde::Serialize;
 use std::io::Error as IoError;
@@ -20,6 +23,9 @@ pub struct CommandResponse {
 pub struct AppVersionInfo {
     pub launcher_version: String,
     pub rustfs_version: String,
+    pub bundled_rustfs_version: Option<String>,
+    pub rustfs_managed: bool,
+    pub platform: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -148,15 +154,16 @@ pub async fn get_runtime_status(host: String, port: u16) -> Result<RuntimeStatus
 
 #[tauri::command]
 pub fn get_app_version_info(app: AppHandle) -> AppVersionInfo {
+    let effective = binaries::effective_version();
     AppVersionInfo {
         launcher_version: app.package_info().version.to_string(),
-        rustfs_version: option_env!("RUSTFS_VERSION")
-            .unwrap_or("unknown")
-            .to_string(),
+        rustfs_version: effective.version,
+        bundled_rustfs_version: binaries::bundled_version().map(str::to_string),
+        rustfs_managed: effective.managed,
+        platform: platform::current_label(),
     }
 }
 
-#[tauri::command]
 fn is_http_url(url: &str) -> bool {
     let scheme_ok = url.starts_with("http://") || url.starts_with("https://");
     scheme_ok && !url.chars().any(|ch| ch.is_control() || ch.is_whitespace())
@@ -255,6 +262,26 @@ pub async fn install_update(app: AppHandle) -> Result<CommandResponse> {
 
     add_app_log("Update installed; restarting launcher".to_string());
     app.restart();
+}
+
+/// Checks <https://version.rustfs.com/latest.json> for a newer RustFS build.
+/// This is independent of the launcher's own self-update.
+#[tauri::command]
+pub async fn check_rustfs_update() -> Result<RustFsUpdateInfo> {
+    rustfs_update::check().await
+}
+
+/// Downloads, verifies, and installs the latest RustFS build for this platform.
+#[tauri::command]
+pub async fn install_rustfs_update() -> Result<CommandResponse> {
+    let message = rustfs_update::install().await.inspect_err(|error| {
+        add_app_log(format!("RustFS update failed: {error}"));
+    })?;
+
+    Ok(CommandResponse {
+        success: true,
+        message,
+    })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,5 +1,11 @@
 use serde::{Deserialize, Serialize};
 
+pub const DEFAULT_API_PORT: u16 = 9000;
+pub const DEFAULT_CONSOLE_PORT: u16 = 9001;
+pub const DEFAULT_HOST: &str = "127.0.0.1";
+pub const DEFAULT_ACCESS_KEY: &str = "rustfsadmin";
+pub const DEFAULT_SECRET_KEY: &str = "rustfsadmin";
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct RustFsConfig {
@@ -23,11 +29,11 @@ impl Default for RustFsConfig {
         Self {
             binary_path: None,
             data_path: String::new(),
-            port: Some(9000),
-            console_port: Some(9001),
-            host: Some("127.0.0.1".to_string()),
-            access_key: Some("rustfsadmin".to_string()),
-            secret_key: Some("rustfsadmin".to_string()),
+            port: Some(DEFAULT_API_PORT),
+            console_port: Some(DEFAULT_CONSOLE_PORT),
+            host: Some(DEFAULT_HOST.to_string()),
+            access_key: Some(DEFAULT_ACCESS_KEY.to_string()),
+            secret_key: Some(DEFAULT_SECRET_KEY.to_string()),
             console_enable: false,
         }
     }
@@ -38,15 +44,15 @@ impl RustFsConfig {
         self.host
             .as_deref()
             .filter(|host| !host.is_empty())
-            .unwrap_or("127.0.0.1")
+            .unwrap_or(DEFAULT_HOST)
     }
 
     pub fn api_port(&self) -> u16 {
-        self.port.unwrap_or(9000)
+        self.port.unwrap_or(DEFAULT_API_PORT)
     }
 
     pub fn console_port(&self) -> u16 {
-        self.console_port.unwrap_or(9001)
+        self.console_port.unwrap_or(DEFAULT_CONSOLE_PORT)
     }
 }
 

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -43,6 +43,25 @@ pub enum Error {
 
     #[error("Update failed: {0}")]
     Update(String),
+
+    #[error("RustFS Launcher supports Windows and macOS only (detected {0})")]
+    UnsupportedPlatform(String),
+
+    #[error("Network request failed: {0}")]
+    Network(String),
+
+    #[error("Release asset not found: {0}")]
+    AssetNotFound(String),
+
+    #[error("Checksum mismatch for {asset}: expected {expected}, got {actual}")]
+    ChecksumMismatch {
+        asset: String,
+        expected: String,
+        actual: String,
+    },
+
+    #[error("RustFS update failed: {0}")]
+    RustFsUpdate(String),
 }
 
 impl Serialize for Error {
@@ -55,3 +74,38 @@ impl Serialize for Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn serializes_as_the_display_string_for_the_frontend() {
+        let error = Error::PortInUse(9000);
+        assert_eq!(
+            serde_json::to_string(&error).unwrap(),
+            "\"Port 9000 is already in use\""
+        );
+    }
+
+    #[test]
+    fn unsupported_platform_names_the_supported_targets() {
+        let message = Error::UnsupportedPlatform("linux-x86_64".to_string()).to_string();
+        assert!(message.contains("Windows"));
+        assert!(message.contains("macOS"));
+        assert!(message.contains("linux-x86_64"));
+    }
+
+    #[test]
+    fn checksum_mismatch_reports_both_digests() {
+        let message = Error::ChecksumMismatch {
+            asset: "rustfs-windows-x86_64-v1.0.0.zip".to_string(),
+            expected: "aaa".to_string(),
+            actual: "bbb".to_string(),
+        }
+        .to_string();
+        assert!(message.contains("rustfs-windows-x86_64-v1.0.0.zip"));
+        assert!(message.contains("aaa"));
+        assert!(message.contains("bbb"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,12 @@
+mod binaries;
 mod commands;
 mod config;
 mod error;
+mod platform;
 mod process;
+mod rustfs_update;
 mod state;
+mod version;
 
 use state::{add_app_log, set_app_handle, terminate_rustfs_process};
 use tauri::{
@@ -26,10 +30,8 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_single_instance::init(
             |app, _arguments, _cwd| {
@@ -40,12 +42,24 @@ pub fn run() {
             set_app_handle(app.handle().clone());
             add_app_log("RustFS Launcher started".to_string());
 
+            add_app_log(format!("Detected platform: {}", platform::current_label()));
+            if let Err(error) = platform::Platform::detect() {
+                add_app_log(format!("WARNING: {error}"));
+            }
+
             let quit_i = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
             let show_i = MenuItem::with_id(app, "show", "Show", true, None::<&str>)?;
             let menu = Menu::with_items(app, &[&show_i, &quit_i])?;
 
-            let _tray = TrayIconBuilder::with_id("rustfs-tray")
-                .icon(app.default_window_icon().unwrap().clone())
+            let mut tray = TrayIconBuilder::with_id("rustfs-tray");
+            match app.default_window_icon() {
+                Some(icon) => tray = tray.icon(icon.clone()),
+                // A tray entry without an icon still works and is far better
+                // than refusing to start the launcher.
+                None => log::warn!("No default window icon; tray icon will use the system default"),
+            }
+
+            let _tray = tray
                 .menu(&menu)
                 .show_menu_on_left_click(false)
                 .on_menu_event(|app, event| match event.id.as_ref() {
@@ -103,7 +117,9 @@ pub fn run() {
             commands::get_app_version_info,
             commands::open_service_url,
             commands::check_for_update,
-            commands::install_update
+            commands::install_update,
+            commands::check_rustfs_update,
+            commands::install_rustfs_update
         ])
         .build(tauri::generate_context!())
         .expect("error building tauri application")

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -108,6 +108,22 @@ mod tests {
     }
 
     #[test]
+    fn detect_accepts_only_shipped_desktop_targets() {
+        let detected = Platform::detect();
+        match (std::env::consts::OS, std::env::consts::ARCH) {
+            ("macos", "aarch64" | "x86_64") | ("windows", "x86_64" | "aarch64") => {
+                assert!(detected.is_ok());
+            }
+            _ => {
+                let error = detected.unwrap_err();
+                assert!(matches!(error, Error::UnsupportedPlatform(_)));
+                assert!(error.to_string().contains("Windows"));
+                assert!(error.to_string().contains("macOS"));
+            }
+        }
+    }
+
+    #[test]
     fn asset_slug_drops_the_windows_extension() {
         assert_eq!(
             Platform::from_target("windows", "x86_64")

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -1,0 +1,125 @@
+use crate::error::{Error, Result};
+
+/// Desktop targets the launcher ships installers for. Linux is intentionally
+/// absent: upstream RustFS publishes gnu/musl variants that need a per-distro
+/// decision the launcher cannot make, and no Linux bundle is released.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Platform {
+    MacOsAarch64,
+    MacOsX86_64,
+    WindowsX86_64,
+}
+
+impl Platform {
+    pub fn detect() -> Result<Self> {
+        Self::from_target(std::env::consts::OS, std::env::consts::ARCH)
+    }
+
+    pub fn from_target(os: &str, arch: &str) -> Result<Self> {
+        match (os, arch) {
+            ("macos", "aarch64") => Ok(Self::MacOsAarch64),
+            ("macos", "x86_64") => Ok(Self::MacOsX86_64),
+            // Windows on ARM runs the x86_64 build under emulation because
+            // upstream does not publish a native aarch64 Windows binary.
+            ("windows", "x86_64") | ("windows", "aarch64") => Ok(Self::WindowsX86_64),
+            _ => Err(Error::UnsupportedPlatform(format!("{os}-{arch}"))),
+        }
+    }
+
+    /// File name of the RustFS binary as staged by the build scripts.
+    pub fn binary_name(self) -> &'static str {
+        match self {
+            Self::MacOsAarch64 => "rustfs-macos-aarch64",
+            Self::MacOsX86_64 => "rustfs-macos-x86_64",
+            Self::WindowsX86_64 => "rustfs-windows-x86_64.exe",
+        }
+    }
+
+    /// Prefix of the upstream release archive, without the version suffix.
+    pub fn asset_slug(self) -> &'static str {
+        match self {
+            Self::MacOsAarch64 => "rustfs-macos-aarch64",
+            Self::MacOsX86_64 => "rustfs-macos-x86_64",
+            Self::WindowsX86_64 => "rustfs-windows-x86_64",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::MacOsAarch64 => "macOS (Apple Silicon)",
+            Self::MacOsX86_64 => "macOS (Intel)",
+            Self::WindowsX86_64 => "Windows (x86_64)",
+        }
+    }
+}
+
+pub fn current_label() -> String {
+    Platform::detect()
+        .map(|platform| platform.label().to_string())
+        .unwrap_or_else(|_| {
+            format!(
+                "{}-{} (unsupported)",
+                std::env::consts::OS,
+                std::env::consts::ARCH
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Platform;
+    use crate::error::Error;
+
+    #[test]
+    fn maps_supported_desktop_targets() {
+        assert_eq!(
+            Platform::from_target("macos", "aarch64")
+                .unwrap()
+                .binary_name(),
+            "rustfs-macos-aarch64"
+        );
+        assert_eq!(
+            Platform::from_target("macos", "x86_64")
+                .unwrap()
+                .binary_name(),
+            "rustfs-macos-x86_64"
+        );
+        assert_eq!(
+            Platform::from_target("windows", "x86_64")
+                .unwrap()
+                .binary_name(),
+            "rustfs-windows-x86_64.exe"
+        );
+        assert_eq!(
+            Platform::from_target("windows", "aarch64")
+                .unwrap()
+                .binary_name(),
+            "rustfs-windows-x86_64.exe"
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_targets_with_the_target_triple() {
+        let error = Platform::from_target("linux", "x86_64").unwrap_err();
+        assert!(matches!(error, Error::UnsupportedPlatform(_)));
+        assert!(error.to_string().contains("linux-x86_64"));
+
+        assert!(Platform::from_target("macos", "riscv64").is_err());
+    }
+
+    #[test]
+    fn asset_slug_drops_the_windows_extension() {
+        assert_eq!(
+            Platform::from_target("windows", "x86_64")
+                .unwrap()
+                .asset_slug(),
+            "rustfs-windows-x86_64"
+        );
+        assert_eq!(
+            Platform::from_target("macos", "aarch64")
+                .unwrap()
+                .asset_slug(),
+            "rustfs-macos-aarch64"
+        );
+    }
+}

--- a/src-tauri/src/process.rs
+++ b/src-tauri/src/process.rs
@@ -1,3 +1,4 @@
+use crate::binaries;
 use crate::config::RustFsConfig;
 use crate::error::{Error, Result};
 use crate::state::{
@@ -12,27 +13,6 @@ use std::time::{Duration, Instant};
 use tauri::Manager;
 
 const EARLY_EXIT_WAIT: Duration = Duration::from_millis(400);
-
-pub(crate) fn inferred_binary_name_for(os: &str, arch: &str) -> &'static str {
-    match (os, arch) {
-        ("macos", "aarch64") => "rustfs-macos-aarch64",
-        ("macos", "x86_64") => "rustfs-macos-x86_64",
-        ("windows", "x86_64") | ("windows", "aarch64") => "rustfs-windows-x86_64.exe",
-        ("linux", "x86_64") => "rustfs-linux-x86_64",
-        ("linux", "aarch64") => "rustfs-linux-aarch64",
-        _ => {
-            if os == "windows" {
-                "rustfs-windows-x86_64.exe"
-            } else {
-                "rustfs"
-            }
-        }
-    }
-}
-
-fn inferred_binary_name() -> &'static str {
-    inferred_binary_name_for(std::env::consts::OS, std::env::consts::ARCH)
-}
 
 pub(crate) fn format_bind_address(host: &str, port: u16) -> String {
     if host.contains(':') && !host.starts_with('[') {
@@ -145,6 +125,17 @@ fn resource_dir_from_app() -> Option<PathBuf> {
 }
 
 fn get_binary_path() -> Result<PathBuf> {
+    // A binary installed through the in-app RustFS update wins over the copy
+    // bundled with the launcher, as long as it is not the older of the two.
+    if let Some((path, record)) = binaries::installed_binary() {
+        add_app_log(format!(
+            "Using RustFS {} installed by the launcher at {}",
+            record.version,
+            path.display()
+        ));
+        return Ok(path);
+    }
+
     let current_exe = std::env::current_exe().map_err(Error::Io)?;
     let exe_dir = current_exe.parent().ok_or_else(|| {
         Error::Io(std::io::Error::new(
@@ -152,7 +143,7 @@ fn get_binary_path() -> Result<PathBuf> {
             "Parent directory of executable not found",
         ))
     })?;
-    let binary_name = inferred_binary_name();
+    let binary_name = binaries::binary_name()?;
     let env_dir = std::env::var_os("RUSTFS_BINARY_DIR").map(PathBuf::from);
     let cwd = std::env::current_dir().ok();
     let resource_dir = resource_dir_from_app();
@@ -189,7 +180,7 @@ fn get_binary_path() -> Result<PathBuf> {
     ))
 }
 
-fn apply_no_window(cmd: &mut Command) {
+pub(crate) fn apply_no_window(cmd: &mut Command) {
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
@@ -446,26 +437,6 @@ mod tests {
     use crate::config::RustFsConfig;
     use std::fs;
     use std::path::PathBuf;
-
-    #[test]
-    fn infers_platform_binary_names() {
-        assert_eq!(
-            inferred_binary_name_for("macos", "aarch64"),
-            "rustfs-macos-aarch64"
-        );
-        assert_eq!(
-            inferred_binary_name_for("macos", "x86_64"),
-            "rustfs-macos-x86_64"
-        );
-        assert_eq!(
-            inferred_binary_name_for("windows", "x86_64"),
-            "rustfs-windows-x86_64.exe"
-        );
-        assert_eq!(
-            inferred_binary_name_for("windows", "aarch64"),
-            "rustfs-windows-x86_64.exe"
-        );
-    }
 
     #[test]
     fn wraps_ipv6_bind_addresses() {

--- a/src-tauri/src/process.rs
+++ b/src-tauri/src/process.rs
@@ -124,38 +124,19 @@ fn resource_dir_from_app() -> Option<PathBuf> {
         .and_then(|app| app.path().resource_dir().ok())
 }
 
-fn get_binary_path() -> Result<PathBuf> {
-    // A binary installed through the in-app RustFS update wins over the copy
-    // bundled with the launcher, as long as it is not the older of the two.
-    if let Some((path, record)) = binaries::installed_binary() {
-        add_app_log(format!(
-            "Using RustFS {} installed by the launcher at {}",
-            record.version,
-            path.display()
-        ));
+pub(crate) fn resolve_runtime_binary(
+    installed: Option<PathBuf>,
+    exe_dir: &Path,
+    cwd: Option<&Path>,
+    env_dir: Option<&Path>,
+    resource_dir: Option<&Path>,
+    binary_name: &str,
+) -> Result<PathBuf> {
+    if let Some(path) = installed.filter(|path| path.is_file()) {
         return Ok(path);
     }
 
-    let current_exe = std::env::current_exe().map_err(Error::Io)?;
-    let exe_dir = current_exe.parent().ok_or_else(|| {
-        Error::Io(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "Parent directory of executable not found",
-        ))
-    })?;
-    let binary_name = binaries::binary_name()?;
-    let env_dir = std::env::var_os("RUSTFS_BINARY_DIR").map(PathBuf::from);
-    let cwd = std::env::current_dir().ok();
-    let resource_dir = resource_dir_from_app();
-
-    let candidates = binary_candidates(
-        exe_dir,
-        cwd.as_deref(),
-        env_dir.as_deref(),
-        resource_dir.as_deref(),
-        binary_name,
-    );
-
+    let candidates = binary_candidates(exe_dir, cwd, env_dir, resource_dir, binary_name);
     for candidate in &candidates {
         add_app_log(format!(
             "Checking RustFS binary candidate: {}",
@@ -178,6 +159,40 @@ fn get_binary_path() -> Result<PathBuf> {
             .map(|path| path.to_string_lossy().to_string())
             .unwrap_or_else(|| "<unknown>".to_string()),
     ))
+}
+
+fn get_binary_path() -> Result<PathBuf> {
+    // A binary installed through the in-app RustFS update wins over the copy
+    // bundled with the launcher, as long as it is not the older of the two.
+    let installed = binaries::installed_binary().map(|(path, record)| {
+        add_app_log(format!(
+            "Using RustFS {} installed by the launcher at {}",
+            record.version,
+            path.display()
+        ));
+        path
+    });
+
+    let current_exe = std::env::current_exe().map_err(Error::Io)?;
+    let exe_dir = current_exe.parent().ok_or_else(|| {
+        Error::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Parent directory of executable not found",
+        ))
+    })?;
+    let binary_name = binaries::binary_name()?;
+    let env_dir = std::env::var_os("RUSTFS_BINARY_DIR").map(PathBuf::from);
+    let cwd = std::env::current_dir().ok();
+    let resource_dir = resource_dir_from_app();
+
+    resolve_runtime_binary(
+        installed,
+        exe_dir,
+        cwd.as_deref(),
+        env_dir.as_deref(),
+        resource_dir.as_deref(),
+        binary_name,
+    )
 }
 
 pub(crate) fn apply_no_window(cmd: &mut Command) {
@@ -504,6 +519,55 @@ mod tests {
             || path
                 .to_string_lossy()
                 .contains("resources/binaries/rustfs-windows-x86_64.exe")));
+    }
+
+    #[test]
+    fn resolve_runtime_binary_prefers_an_installed_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let installed = dir.path().join("installed");
+        let bundled = dir.path().join("binaries").join("rustfs-macos-aarch64");
+        std::fs::create_dir_all(bundled.parent().unwrap()).unwrap();
+        std::fs::write(&installed, b"new").unwrap();
+        std::fs::write(&bundled, b"old").unwrap();
+
+        let resolved = resolve_runtime_binary(
+            Some(installed.clone()),
+            dir.path(),
+            None,
+            None,
+            None,
+            "rustfs-macos-aarch64",
+        )
+        .unwrap();
+        assert_eq!(resolved, installed);
+
+        let missing_install = dir.path().join("gone");
+        let fallback = resolve_runtime_binary(
+            Some(missing_install),
+            dir.path(),
+            None,
+            None,
+            None,
+            "rustfs-macos-aarch64",
+        )
+        .unwrap();
+        assert_eq!(fallback, bundled);
+    }
+
+    #[test]
+    fn resolve_runtime_binary_reports_the_first_candidate_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let error = resolve_runtime_binary(
+            None,
+            dir.path(),
+            None,
+            None,
+            None,
+            "rustfs-windows-x86_64.exe",
+        )
+        .unwrap_err();
+        assert!(matches!(error, Error::BinaryNotFound(_)));
+        assert!(error.to_string().contains("rustfs-windows-x86_64.exe"));
     }
 
     #[test]

--- a/src-tauri/src/rustfs_update.rs
+++ b/src-tauri/src/rustfs_update.rs
@@ -1,0 +1,556 @@
+//! Manual RustFS binary updates.
+//!
+//! The launcher ships a RustFS build inside its installer, but users should not
+//! have to reinstall the launcher to pick up a new RustFS release. This module
+//! resolves the latest upstream release, downloads the archive for the current
+//! platform, verifies it against the release `SHA256SUMS`, and installs it into
+//! the writable app data directory.
+
+use crate::binaries::{self, InstalledRecord};
+use crate::error::{Error, Result};
+use crate::platform::Platform;
+use crate::state::{acquire, add_app_log, APP_HANDLE};
+use crate::version;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tauri::{Emitter, Manager};
+
+const LATEST_JSON_URL: &str = "https://version.rustfs.com/latest.json";
+const RELEASE_DOWNLOAD_BASE: &str = "https://github.com/rustfs/rustfs/releases/download";
+const CHECKSUM_FILE: &str = "SHA256SUMS";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
+const PROGRESS_EVENT: &str = "rustfs-update-progress";
+
+/// Shape of <https://version.rustfs.com/latest.json>.
+#[derive(Debug, Deserialize)]
+struct LatestRelease {
+    version: Option<String>,
+    tag: Option<String>,
+    release_date: Option<String>,
+    release_type: Option<String>,
+    download_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RustFsUpdateInfo {
+    pub available: bool,
+    pub current_version: String,
+    pub current_managed: bool,
+    pub latest_version: Option<String>,
+    pub release_date: Option<String>,
+    pub release_type: Option<String>,
+    pub release_url: Option<String>,
+    pub asset_name: Option<String>,
+    pub platform: String,
+    pub rustfs_running: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "event", rename_all = "camelCase")]
+enum Stage {
+    Started {
+        asset: String,
+        content_length: Option<u64>,
+    },
+    Progress {
+        downloaded: u64,
+        content_length: Option<u64>,
+    },
+    Verifying,
+    Installing,
+    Finished {
+        version: String,
+    },
+}
+
+fn emit_progress(stage: Stage) {
+    if let Some(handle) = acquire(&APP_HANDLE).as_ref() {
+        let _ = handle.emit(PROGRESS_EVENT, stage);
+    }
+}
+
+fn client(timeout: Duration) -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .user_agent(concat!("rustfs-launcher/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|error| Error::Network(error.to_string()))
+}
+
+async fn fetch_text(url: &str, timeout: Duration) -> Result<String> {
+    let response = client(timeout)?
+        .get(url)
+        .send()
+        .await
+        .map_err(|error| Error::Network(error.to_string()))?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(Error::AssetNotFound(url.to_string()));
+    }
+    let response = response
+        .error_for_status()
+        .map_err(|error| Error::Network(error.to_string()))?;
+
+    response
+        .text()
+        .await
+        .map_err(|error| Error::Network(error.to_string()))
+}
+
+/// Builds the archive name upstream publishes for a platform and tag, e.g.
+/// `rustfs-macos-aarch64-v1.0.0-rc.4.zip`.
+pub(crate) fn asset_name(platform: Platform, tag: &str) -> String {
+    format!(
+        "{}-{}.zip",
+        platform.asset_slug(),
+        version::asset_version(tag)
+    )
+}
+
+fn asset_url(tag: &str, asset: &str) -> String {
+    format!(
+        "{RELEASE_DOWNLOAD_BASE}/{}/{asset}",
+        version::normalize(tag)
+    )
+}
+
+/// Extracts the digest for `asset` out of a `sha256sum`-style manifest.
+pub(crate) fn digest_for_asset(manifest: &str, asset: &str) -> Option<String> {
+    manifest.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        let digest = fields.next()?;
+        let name = fields.next()?.trim_start_matches('*');
+        (name == asset && digest.len() == 64).then(|| digest.to_ascii_lowercase())
+    })
+}
+
+async fn resolve_latest() -> Result<(String, LatestRelease)> {
+    let body = fetch_text(LATEST_JSON_URL, REQUEST_TIMEOUT).await?;
+    let release: LatestRelease = serde_json::from_str(&body).map_err(|error| {
+        Error::RustFsUpdate(format!(
+            "Could not parse the upstream version feed: {error}"
+        ))
+    })?;
+
+    let tag = release
+        .tag
+        .as_deref()
+        .or(release.version.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            Error::RustFsUpdate("Upstream version feed did not report a release tag".to_string())
+        })?
+        .to_string();
+
+    Ok((tag, release))
+}
+
+pub async fn check() -> Result<RustFsUpdateInfo> {
+    let platform = Platform::detect()?;
+    let current = binaries::effective_version();
+    let (tag, release) = resolve_latest().await?;
+
+    let available = version::is_newer(&tag, &current.version);
+    add_app_log(format!(
+        "RustFS update check: installed={}, latest={tag}, available={available}",
+        current.version
+    ));
+
+    Ok(RustFsUpdateInfo {
+        available,
+        current_version: current.version,
+        current_managed: current.managed,
+        latest_version: Some(version::normalize(&tag).to_string()),
+        release_date: release.release_date,
+        release_type: release.release_type,
+        release_url: release
+            .download_url
+            .filter(|url| url.starts_with("https://") && !url.chars().any(char::is_whitespace)),
+        asset_name: Some(asset_name(platform, &tag)),
+        platform: platform.label().to_string(),
+        rustfs_running: crate::state::is_rustfs_process_running(),
+    })
+}
+
+fn cache_dir() -> Result<PathBuf> {
+    let handle = acquire(&APP_HANDLE);
+    let dir = handle
+        .as_ref()
+        .and_then(|app| app.path().app_cache_dir().ok())
+        .ok_or_else(|| {
+            Error::RustFsUpdate("Unable to resolve the launcher cache directory".to_string())
+        })?;
+    drop(handle);
+
+    let dir = dir.join("rustfs-update");
+    std::fs::create_dir_all(&dir).map_err(Error::Io)?;
+    Ok(dir)
+}
+
+async fn download_and_verify(url: &str, asset: &str, expected: &str, dest: &Path) -> Result<()> {
+    let mut response = client(DOWNLOAD_TIMEOUT)?
+        .get(url)
+        .send()
+        .await
+        .map_err(|error| Error::Network(error.to_string()))?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(Error::AssetNotFound(asset.to_string()));
+    }
+    response = response
+        .error_for_status()
+        .map_err(|error| Error::Network(error.to_string()))?;
+
+    let content_length = response.content_length();
+    emit_progress(Stage::Started {
+        asset: asset.to_string(),
+        content_length,
+    });
+
+    let mut file = std::fs::File::create(dest).map_err(Error::Io)?;
+    let mut hasher = Sha256::new();
+    let mut downloaded = 0_u64;
+    let mut last_reported = 0_u64;
+
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| Error::Network(error.to_string()))?
+    {
+        hasher.update(&chunk);
+        file.write_all(&chunk).map_err(Error::Io)?;
+        downloaded += chunk.len() as u64;
+
+        // Throttle to ~1 event per 512 KiB so the webview is not flooded.
+        if downloaded - last_reported >= 512 * 1024 {
+            last_reported = downloaded;
+            emit_progress(Stage::Progress {
+                downloaded,
+                content_length,
+            });
+        }
+    }
+    file.flush().map_err(Error::Io)?;
+    drop(file);
+
+    emit_progress(Stage::Progress {
+        downloaded,
+        content_length,
+    });
+    emit_progress(Stage::Verifying);
+
+    let actual = hex_digest(&hasher.finalize());
+    if actual != expected.to_ascii_lowercase() {
+        let _ = std::fs::remove_file(dest);
+        return Err(Error::ChecksumMismatch {
+            asset: asset.to_string(),
+            expected: expected.to_ascii_lowercase(),
+            actual,
+        });
+    }
+
+    Ok(())
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .fold(String::with_capacity(64), |mut acc, byte| {
+            use std::fmt::Write as _;
+            let _ = write!(acc, "{byte:02x}");
+            acc
+        })
+}
+
+/// Pulls the `rustfs` executable out of an upstream release archive.
+pub(crate) fn extract_binary(archive: &Path, dest: &Path) -> Result<()> {
+    let file = std::fs::File::open(archive).map_err(Error::Io)?;
+    let mut zip = zip::ZipArchive::new(file)
+        .map_err(|error| Error::RustFsUpdate(format!("Could not open the archive: {error}")))?;
+
+    let index = (0..zip.len())
+        .find(|index| {
+            zip.by_index(*index)
+                .ok()
+                .and_then(|entry| {
+                    entry.enclosed_name().and_then(|path| {
+                        path.file_name()
+                            .map(|name| name.to_string_lossy().to_ascii_lowercase())
+                    })
+                })
+                .is_some_and(|name| name == "rustfs" || name == "rustfs.exe")
+        })
+        .ok_or_else(|| {
+            Error::RustFsUpdate("Archive did not contain a rustfs executable".to_string())
+        })?;
+
+    let mut entry = zip
+        .by_index(index)
+        .map_err(|error| Error::RustFsUpdate(format!("Could not read the archive: {error}")))?;
+    let mut out = std::fs::File::create(dest).map_err(Error::Io)?;
+    std::io::copy(&mut entry, &mut out).map_err(Error::Io)?;
+    out.flush().map_err(Error::Io)?;
+    drop(out);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o755))
+            .map_err(Error::Io)?;
+    }
+
+    Ok(())
+}
+
+/// Runs `--version` on a freshly extracted binary so a truncated or
+/// architecture-mismatched download is rejected before it replaces a working
+/// install.
+fn smoke_test(path: &Path) -> Result<String> {
+    let mut command = std::process::Command::new(path);
+    command.arg("--version");
+    crate::process::apply_no_window(&mut command);
+
+    let output = command.output().map_err(|error| {
+        Error::RustFsUpdate(format!("Downloaded RustFS binary is not runnable: {error}"))
+    })?;
+
+    if !output.status.success() {
+        return Err(Error::RustFsUpdate(format!(
+            "Downloaded RustFS binary exited with {} when asked for its version",
+            output.status
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Replaces `target` with `staged`, keeping a rollback copy while doing so.
+/// Windows refuses to overwrite a file that is still mapped, so the previous
+/// binary is moved aside instead of deleted in place.
+fn swap_in_place(staged: &Path, target: &Path) -> Result<()> {
+    if !target.exists() {
+        return std::fs::rename(staged, target).map_err(Error::Io);
+    }
+
+    let backup = target.with_extension("previous");
+    let _ = std::fs::remove_file(&backup);
+    std::fs::rename(target, &backup).map_err(Error::Io)?;
+
+    match std::fs::rename(staged, target) {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&backup);
+            Ok(())
+        }
+        Err(error) => {
+            let _ = std::fs::rename(&backup, target);
+            Err(Error::Io(error))
+        }
+    }
+}
+
+pub async fn install() -> Result<String> {
+    let platform = Platform::detect()?;
+    let (tag, _) = resolve_latest().await?;
+    let current = binaries::effective_version();
+
+    if !version::is_newer(&tag, &current.version) {
+        return Err(Error::RustFsUpdate(format!(
+            "RustFS {} is already the latest release",
+            current.version
+        )));
+    }
+
+    let asset = asset_name(platform, &tag);
+    let manifest = fetch_text(&asset_url(&tag, CHECKSUM_FILE), REQUEST_TIMEOUT).await?;
+    let expected = digest_for_asset(&manifest, &asset).ok_or_else(|| {
+        Error::AssetNotFound(format!(
+            "{asset} is not listed in {CHECKSUM_FILE} for {tag}"
+        ))
+    })?;
+
+    let cache = cache_dir()?;
+    let archive = cache.join(&asset);
+    add_app_log(format!("Downloading RustFS {tag} ({asset})"));
+    download_and_verify(&asset_url(&tag, &asset), &asset, &expected, &archive).await?;
+    add_app_log(format!("Verified {asset} against {CHECKSUM_FILE}"));
+
+    emit_progress(Stage::Installing);
+    let managed_dir = binaries::ensure_managed_dir()?;
+    let binary_name = platform.binary_name();
+    let staged = managed_dir.join(format!("{binary_name}.staged"));
+    let target = managed_dir.join(binary_name);
+
+    let archive_for_task = archive.clone();
+    let staged_for_task = staged.clone();
+    let reported = tauri::async_runtime::spawn_blocking(move || {
+        extract_binary(&archive_for_task, &staged_for_task)?;
+        smoke_test(&staged_for_task)
+    })
+    .await
+    .map_err(|error| Error::RustFsUpdate(error.to_string()))?
+    .inspect_err(|_| {
+        let _ = std::fs::remove_file(&staged);
+    })?;
+    if !reported.is_empty() {
+        add_app_log(format!("Downloaded binary reports: {reported}"));
+    }
+
+    let was_running = crate::state::is_rustfs_process_running();
+    if was_running {
+        add_app_log("Stopping RustFS before swapping in the new binary".to_string());
+        crate::state::terminate_rustfs_process();
+    }
+
+    swap_in_place(&staged, &target)?;
+    let _ = std::fs::remove_file(&archive);
+
+    binaries::write_record(
+        &managed_dir,
+        &InstalledRecord {
+            version: version::normalize(&tag).to_string(),
+            binary: binary_name.to_string(),
+            asset: asset.clone(),
+            sha256: expected,
+            installed_at: chrono::Utc::now().to_rfc3339(),
+        },
+    )?;
+
+    let installed = version::normalize(&tag).to_string();
+    add_app_log(format!(
+        "RustFS {installed} installed at {}",
+        target.display()
+    ));
+    emit_progress(Stage::Finished {
+        version: installed.clone(),
+    });
+
+    Ok(if was_running {
+        format!("RustFS {installed} installed. The previous instance was stopped; launch it again to use the new build.")
+    } else {
+        format!("RustFS {installed} installed.")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{asset_name, asset_url, digest_for_asset, extract_binary, swap_in_place};
+    use crate::platform::Platform;
+    use std::io::Write;
+
+    const MANIFEST: &str = "\
+f3acebb751620d940c87882afc811210fc2e186f457978b83819a04df6087722  rustfs-linux-aarch64-gnu-v1.0.0-rc.4.zip
+6c6a0e841466ffb3c8ffa7299624876c12ef6ce3ff5af11b8afb55c23fd9c3d7  rustfs-macos-aarch64-v1.0.0-rc.4.zip
+B34390D7CE5C1797B4A127261FEE1926C2AED1D280E1EC59F149F255902221AF *rustfs-windows-x86_64-v1.0.0-rc.4.zip
+";
+
+    #[test]
+    fn builds_upstream_asset_names_and_urls() {
+        let macos = Platform::from_target("macos", "aarch64").unwrap();
+        assert_eq!(
+            asset_name(macos, "1.0.0-rc.4"),
+            "rustfs-macos-aarch64-v1.0.0-rc.4.zip"
+        );
+        assert_eq!(
+            asset_name(macos, "v1.0.0-rc.4"),
+            "rustfs-macos-aarch64-v1.0.0-rc.4.zip"
+        );
+
+        let windows = Platform::from_target("windows", "aarch64").unwrap();
+        assert_eq!(
+            asset_name(windows, "1.0.0-rc.4"),
+            "rustfs-windows-x86_64-v1.0.0-rc.4.zip"
+        );
+
+        assert_eq!(
+            asset_url("v1.0.0-rc.4", "SHA256SUMS"),
+            "https://github.com/rustfs/rustfs/releases/download/1.0.0-rc.4/SHA256SUMS"
+        );
+    }
+
+    #[test]
+    fn reads_digests_out_of_the_checksum_manifest() {
+        assert_eq!(
+            digest_for_asset(MANIFEST, "rustfs-macos-aarch64-v1.0.0-rc.4.zip").as_deref(),
+            Some("6c6a0e841466ffb3c8ffa7299624876c12ef6ce3ff5af11b8afb55c23fd9c3d7")
+        );
+        assert_eq!(
+            digest_for_asset(MANIFEST, "rustfs-windows-x86_64-v1.0.0-rc.4.zip").as_deref(),
+            Some("b34390d7ce5c1797b4a127261fee1926c2aed1d280e1ec59f149f255902221af")
+        );
+        assert!(digest_for_asset(MANIFEST, "rustfs-macos-x86_64-v1.0.0-rc.4.zip").is_none());
+        assert!(digest_for_asset("short  file.zip", "file.zip").is_none());
+    }
+
+    fn write_zip(path: &std::path::Path, entries: &[(&str, &[u8])]) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = zip::ZipWriter::new(file);
+        let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default();
+        for (name, contents) in entries {
+            writer.start_file(*name, options).unwrap();
+            writer.write_all(contents).unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    #[test]
+    fn extracts_the_rustfs_executable_from_a_release_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("release.zip");
+        write_zip(
+            &archive,
+            &[("README.md", b"docs"), ("rustfs", b"binary-bytes")],
+        );
+
+        let dest = dir.path().join("rustfs-macos-aarch64");
+        extract_binary(&archive, &dest).unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), b"binary-bytes");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&dest).unwrap().permissions().mode();
+            assert_ne!(mode & 0o111, 0, "extracted binary should be executable");
+        }
+    }
+
+    #[test]
+    fn extraction_fails_when_the_archive_has_no_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("release.zip");
+        write_zip(&archive, &[("README.md", b"docs")]);
+
+        let error = extract_binary(&archive, &dir.path().join("out")).unwrap_err();
+        assert!(error.to_string().contains("rustfs executable"));
+    }
+
+    #[test]
+    fn swap_replaces_an_existing_binary_and_cleans_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("rustfs");
+        let staged = dir.path().join("rustfs.staged");
+        std::fs::write(&target, b"old").unwrap();
+        std::fs::write(&staged, b"new").unwrap();
+
+        swap_in_place(&staged, &target).unwrap();
+
+        assert_eq!(std::fs::read(&target).unwrap(), b"new");
+        assert!(!staged.exists());
+        assert!(!target.with_extension("previous").exists());
+    }
+
+    #[test]
+    fn swap_installs_a_first_time_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("rustfs");
+        let staged = dir.path().join("rustfs.staged");
+        std::fs::write(&staged, b"new").unwrap();
+
+        swap_in_place(&staged, &target).unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"new");
+    }
+}

--- a/src-tauri/src/rustfs_update.rs
+++ b/src-tauri/src/rustfs_update.rs
@@ -26,8 +26,8 @@ const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
 const PROGRESS_EVENT: &str = "rustfs-update-progress";
 
 /// Shape of <https://version.rustfs.com/latest.json>.
-#[derive(Debug, Deserialize)]
-struct LatestRelease {
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct LatestRelease {
     version: Option<String>,
     tag: Option<String>,
     release_date: Option<String>,
@@ -45,6 +45,7 @@ pub struct RustFsUpdateInfo {
     pub release_type: Option<String>,
     pub release_url: Option<String>,
     pub asset_name: Option<String>,
+    pub notes: Option<String>,
     pub platform: String,
     pub rustfs_running: bool,
 }
@@ -128,9 +129,14 @@ pub(crate) fn digest_for_asset(manifest: &str, asset: &str) -> Option<String> {
     })
 }
 
-async fn resolve_latest() -> Result<(String, LatestRelease)> {
-    let body = fetch_text(LATEST_JSON_URL, REQUEST_TIMEOUT).await?;
-    let release: LatestRelease = serde_json::from_str(&body).map_err(|error| {
+#[derive(Debug, Clone)]
+pub(crate) struct FeedSnapshot {
+    pub tag: String,
+    pub release: LatestRelease,
+}
+
+pub(crate) fn parse_latest_feed(body: &str) -> Result<FeedSnapshot> {
+    let release: LatestRelease = serde_json::from_str(body).map_err(|error| {
         Error::RustFsUpdate(format!(
             "Could not parse the upstream version feed: {error}"
         ))
@@ -147,34 +153,79 @@ async fn resolve_latest() -> Result<(String, LatestRelease)> {
         })?
         .to_string();
 
-    Ok((tag, release))
+    Ok(FeedSnapshot { tag, release })
+}
+
+fn safe_release_url(url: Option<&str>) -> Option<String> {
+    url.map(str::trim)
+        .filter(|value| value.starts_with("https://") && !value.chars().any(char::is_whitespace))
+        .map(str::to_string)
+}
+
+pub(crate) fn evaluate_update(
+    platform: Platform,
+    current: &binaries::EffectiveVersion,
+    feed: &FeedSnapshot,
+    rustfs_running: bool,
+    manifest: Option<&str>,
+) -> RustFsUpdateInfo {
+    let asset = asset_name(platform, &feed.tag);
+    let newer = version::is_newer(&feed.tag, &current.version);
+    let asset_listed = manifest.map(|body| digest_for_asset(body, &asset).is_some());
+    let (available, notes) = match (newer, asset_listed) {
+        (true, Some(false)) => (
+            false,
+            Some(format!(
+                "RustFS {} has no {} build.",
+                version::normalize(&feed.tag),
+                platform.label()
+            )),
+        ),
+        (true, _) => (true, None),
+        (false, _) => (false, None),
+    };
+
+    RustFsUpdateInfo {
+        available,
+        current_version: current.version.clone(),
+        current_managed: current.managed,
+        latest_version: Some(version::normalize(&feed.tag).to_string()),
+        release_date: feed.release.release_date.clone(),
+        release_type: feed.release.release_type.clone(),
+        release_url: safe_release_url(feed.release.download_url.as_deref()),
+        asset_name: Some(asset),
+        notes,
+        platform: platform.label().to_string(),
+        rustfs_running,
+    }
+}
+
+async fn resolve_latest() -> Result<FeedSnapshot> {
+    let body = fetch_text(LATEST_JSON_URL, REQUEST_TIMEOUT).await?;
+    parse_latest_feed(&body)
 }
 
 pub async fn check() -> Result<RustFsUpdateInfo> {
     let platform = Platform::detect()?;
     let current = binaries::effective_version();
-    let (tag, release) = resolve_latest().await?;
-
-    let available = version::is_newer(&tag, &current.version);
+    let feed = resolve_latest().await?;
+    let manifest = fetch_text(&asset_url(&feed.tag, CHECKSUM_FILE), REQUEST_TIMEOUT)
+        .await
+        .ok();
+    let info = evaluate_update(
+        platform,
+        &current,
+        &feed,
+        crate::state::is_rustfs_process_running(),
+        manifest.as_deref(),
+    );
     add_app_log(format!(
-        "RustFS update check: installed={}, latest={tag}, available={available}",
-        current.version
+        "RustFS update check: installed={}, latest={}, available={}",
+        info.current_version,
+        info.latest_version.as_deref().unwrap_or("unknown"),
+        info.available
     ));
-
-    Ok(RustFsUpdateInfo {
-        available,
-        current_version: current.version,
-        current_managed: current.managed,
-        latest_version: Some(version::normalize(&tag).to_string()),
-        release_date: release.release_date,
-        release_type: release.release_type,
-        release_url: release
-            .download_url
-            .filter(|url| url.starts_with("https://") && !url.chars().any(char::is_whitespace)),
-        asset_name: Some(asset_name(platform, &tag)),
-        platform: platform.label().to_string(),
-        rustfs_running: crate::state::is_rustfs_process_running(),
-    })
+    Ok(info)
 }
 
 fn cache_dir() -> Result<PathBuf> {
@@ -245,16 +296,44 @@ async fn download_and_verify(url: &str, asset: &str, expected: &str, dest: &Path
     emit_progress(Stage::Verifying);
 
     let actual = hex_digest(&hasher.finalize());
-    if actual != expected.to_ascii_lowercase() {
+    if let Err(error) = verify_sha256(&actual, expected, asset) {
         let _ = std::fs::remove_file(dest);
-        return Err(Error::ChecksumMismatch {
-            asset: asset.to_string(),
-            expected: expected.to_ascii_lowercase(),
-            actual,
-        });
+        return Err(error);
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
+    hex_digest(&Sha256::digest(bytes))
+}
+
+pub(crate) fn verify_sha256(actual: &str, expected: &str, asset: &str) -> Result<()> {
+    let actual = actual.to_ascii_lowercase();
+    let expected = expected.to_ascii_lowercase();
+    if actual != expected {
+        return Err(Error::ChecksumMismatch {
+            asset: asset.to_string(),
+            expected,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn hash_file(path: &Path) -> Result<String> {
+    let mut hasher = Sha256::new();
+    let mut file = std::fs::File::open(path).map_err(Error::Io)?;
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = std::io::Read::read(&mut file, &mut buffer).map_err(Error::Io)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex_digest(&hasher.finalize()))
 }
 
 fn hex_digest(bytes: &[u8]) -> String {
@@ -310,7 +389,7 @@ pub(crate) fn extract_binary(archive: &Path, dest: &Path) -> Result<()> {
 /// Runs `--version` on a freshly extracted binary so a truncated or
 /// architecture-mismatched download is rejected before it replaces a working
 /// install.
-fn smoke_test(path: &Path) -> Result<String> {
+pub(crate) fn smoke_test(path: &Path) -> Result<String> {
     let mut command = std::process::Command::new(path);
     command.arg("--version");
     crate::process::apply_no_window(&mut command);
@@ -353,49 +432,98 @@ fn swap_in_place(staged: &Path, target: &Path) -> Result<()> {
     }
 }
 
+/// Extracts the archive and optionally smoke-tests it before the live binary
+/// is replaced. A failed smoke test leaves the current install untouched.
+pub(crate) fn stage_update(archive: &Path, staged: &Path, run_smoke: bool) -> Result<String> {
+    extract_binary(archive, staged).inspect_err(|_| {
+        let _ = std::fs::remove_file(staged);
+    })?;
+
+    if !run_smoke {
+        return Ok(String::new());
+    }
+
+    match smoke_test(staged) {
+        Ok(reported) => Ok(reported),
+        Err(error) => {
+            let _ = std::fs::remove_file(staged);
+            Err(error)
+        }
+    }
+}
+
+pub(crate) fn commit_update(
+    platform: Platform,
+    tag: &str,
+    asset: &str,
+    sha256: &str,
+    staged: &Path,
+    managed_dir: &Path,
+    was_running: bool,
+) -> Result<String> {
+    std::fs::create_dir_all(managed_dir).map_err(Error::Io)?;
+    let binary_name = platform.binary_name();
+    let target = managed_dir.join(binary_name);
+    swap_in_place(staged, &target)?;
+
+    binaries::write_record(
+        managed_dir,
+        &InstalledRecord {
+            version: version::normalize(tag).to_string(),
+            binary: binary_name.to_string(),
+            asset: asset.to_string(),
+            sha256: sha256.to_ascii_lowercase(),
+            installed_at: chrono::Utc::now().to_rfc3339(),
+        },
+    )?;
+
+    let installed = version::normalize(tag).to_string();
+    Ok(if was_running {
+        format!("RustFS {installed} installed. The previous instance was stopped; launch it again to use the new build.")
+    } else {
+        format!("RustFS {installed} installed.")
+    })
+}
+
 pub async fn install() -> Result<String> {
     let platform = Platform::detect()?;
-    let (tag, _) = resolve_latest().await?;
+    let feed = resolve_latest().await?;
     let current = binaries::effective_version();
 
-    if !version::is_newer(&tag, &current.version) {
+    if !version::is_newer(&feed.tag, &current.version) {
         return Err(Error::RustFsUpdate(format!(
             "RustFS {} is already the latest release",
             current.version
         )));
     }
 
-    let asset = asset_name(platform, &tag);
-    let manifest = fetch_text(&asset_url(&tag, CHECKSUM_FILE), REQUEST_TIMEOUT).await?;
+    let asset = asset_name(platform, &feed.tag);
+    let manifest = fetch_text(&asset_url(&feed.tag, CHECKSUM_FILE), REQUEST_TIMEOUT).await?;
     let expected = digest_for_asset(&manifest, &asset).ok_or_else(|| {
         Error::AssetNotFound(format!(
-            "{asset} is not listed in {CHECKSUM_FILE} for {tag}"
+            "{asset} is not listed in {CHECKSUM_FILE} for {}",
+            feed.tag
         ))
     })?;
 
     let cache = cache_dir()?;
     let archive = cache.join(&asset);
-    add_app_log(format!("Downloading RustFS {tag} ({asset})"));
-    download_and_verify(&asset_url(&tag, &asset), &asset, &expected, &archive).await?;
+    add_app_log(format!("Downloading RustFS {} ({asset})", feed.tag));
+    download_and_verify(&asset_url(&feed.tag, &asset), &asset, &expected, &archive).await?;
+    verify_sha256(&hash_file(&archive)?, &expected, &asset)?;
     add_app_log(format!("Verified {asset} against {CHECKSUM_FILE}"));
 
     emit_progress(Stage::Installing);
     let managed_dir = binaries::ensure_managed_dir()?;
-    let binary_name = platform.binary_name();
-    let staged = managed_dir.join(format!("{binary_name}.staged"));
-    let target = managed_dir.join(binary_name);
+    let staged = managed_dir.join(format!("{}.staged", platform.binary_name()));
 
     let archive_for_task = archive.clone();
     let staged_for_task = staged.clone();
     let reported = tauri::async_runtime::spawn_blocking(move || {
-        extract_binary(&archive_for_task, &staged_for_task)?;
-        smoke_test(&staged_for_task)
+        stage_update(&archive_for_task, &staged_for_task, true)
     })
     .await
-    .map_err(|error| Error::RustFsUpdate(error.to_string()))?
-    .inspect_err(|_| {
-        let _ = std::fs::remove_file(&staged);
-    })?;
+    .map_err(|error| Error::RustFsUpdate(error.to_string()))??;
     if !reported.is_empty() {
         add_app_log(format!("Downloaded binary reports: {reported}"));
     }
@@ -406,41 +534,44 @@ pub async fn install() -> Result<String> {
         crate::state::terminate_rustfs_process();
     }
 
-    swap_in_place(&staged, &target)?;
+    let message = commit_update(
+        platform,
+        &feed.tag,
+        &asset,
+        &expected,
+        &staged,
+        &managed_dir,
+        was_running,
+    )?;
     let _ = std::fs::remove_file(&archive);
 
-    binaries::write_record(
-        &managed_dir,
-        &InstalledRecord {
-            version: version::normalize(&tag).to_string(),
-            binary: binary_name.to_string(),
-            asset: asset.clone(),
-            sha256: expected,
-            installed_at: chrono::Utc::now().to_rfc3339(),
-        },
-    )?;
-
-    let installed = version::normalize(&tag).to_string();
     add_app_log(format!(
-        "RustFS {installed} installed at {}",
-        target.display()
+        "RustFS {} installed at {}",
+        version::normalize(&feed.tag),
+        managed_dir.join(platform.binary_name()).display()
     ));
     emit_progress(Stage::Finished {
-        version: installed.clone(),
+        version: version::normalize(&feed.tag).to_string(),
     });
 
-    Ok(if was_running {
-        format!("RustFS {installed} installed. The previous instance was stopped; launch it again to use the new build.")
-    } else {
-        format!("RustFS {installed} installed.")
-    })
+    Ok(message)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{asset_name, asset_url, digest_for_asset, extract_binary, swap_in_place};
+    use super::{
+        asset_name, asset_url, commit_update, digest_for_asset, evaluate_update, extract_binary,
+        hash_file, parse_latest_feed, sha256_hex, smoke_test, stage_update, swap_in_place,
+        verify_sha256, FeedSnapshot, LatestRelease, Stage,
+    };
+    use crate::binaries::{effective_version_from, installed_binary_from, EffectiveVersion};
+    use crate::error::Error;
     use crate::platform::Platform;
+    use crate::process::launch;
+    use crate::version;
     use std::io::Write;
+    use std::net::TcpListener;
+    use std::process::Command;
 
     const MANIFEST: &str = "\
 f3acebb751620d940c87882afc811210fc2e186f457978b83819a04df6087722  rustfs-linux-aarch64-gnu-v1.0.0-rc.4.zip
@@ -552,5 +683,280 @@ B34390D7CE5C1797B4A127261FEE1926C2AED1D280E1EC59F149F255902221AF *rustfs-windows
 
         swap_in_place(&staged, &target).unwrap();
         assert_eq!(std::fs::read(&target).unwrap(), b"new");
+    }
+
+    #[test]
+    fn extracts_a_windows_exe_from_a_nested_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("release.zip");
+        write_zip(&archive, &[("payload/rustfs.exe", b"mz-bytes")]);
+
+        let dest = dir.path().join("rustfs-windows-x86_64.exe");
+        extract_binary(&archive, &dest).unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), b"mz-bytes");
+    }
+
+    #[test]
+    fn parse_latest_feed_accepts_tag_or_version_and_rejects_junk() {
+        let from_tag = parse_latest_feed(
+            r#"{"tag":"1.0.0-rc.4","version":"ignored","download_url":"https://github.com/rustfs/rustfs/releases/tag/1.0.0-rc.4"}"#,
+        )
+        .unwrap();
+        assert_eq!(from_tag.tag, "1.0.0-rc.4");
+
+        let from_version = parse_latest_feed(r#"{"version":"  v1.2.3  "}"#).unwrap();
+        assert_eq!(from_version.tag, "v1.2.3");
+
+        assert!(parse_latest_feed("not-json").is_err());
+        assert!(parse_latest_feed(r#"{"tag":"","version":""}"#).is_err());
+    }
+
+    fn sample_feed(tag: &str, url: Option<&str>) -> FeedSnapshot {
+        FeedSnapshot {
+            tag: tag.to_string(),
+            release: LatestRelease {
+                version: Some(tag.to_string()),
+                tag: Some(tag.to_string()),
+                release_date: Some("2026-08-28T14:24:08Z".to_string()),
+                release_type: Some("prerelease".to_string()),
+                download_url: url.map(str::to_string),
+            },
+        }
+    }
+
+    #[test]
+    fn evaluate_update_requires_a_newer_release_and_a_platform_asset() {
+        let current = EffectiveVersion {
+            version: "1.0.0-rc.3".to_string(),
+            managed: false,
+        };
+        let windows = Platform::from_target("windows", "x86_64").unwrap();
+        let intel_mac = Platform::from_target("macos", "x86_64").unwrap();
+        let feed = sample_feed(
+            "1.0.0-rc.4",
+            Some("https://github.com/rustfs/rustfs/releases/tag/1.0.0-rc.4"),
+        );
+
+        let ready = evaluate_update(windows, &current, &feed, false, Some(MANIFEST));
+        assert!(ready.available);
+        assert_eq!(ready.latest_version.as_deref(), Some("1.0.0-rc.4"));
+        assert_eq!(
+            ready.release_url.as_deref(),
+            Some("https://github.com/rustfs/rustfs/releases/tag/1.0.0-rc.4")
+        );
+        assert!(ready.notes.is_none());
+
+        let missing = evaluate_update(intel_mac, &current, &feed, true, Some(MANIFEST));
+        assert!(!missing.available);
+        assert!(missing.rustfs_running);
+        assert!(missing.notes.as_deref().unwrap().contains("macOS (Intel)"));
+
+        let current_same = EffectiveVersion {
+            version: "1.0.0-rc.4".to_string(),
+            managed: true,
+        };
+        let already = evaluate_update(windows, &current_same, &feed, false, Some(MANIFEST));
+        assert!(!already.available);
+        assert!(already.current_managed);
+
+        let unsafe_feed = sample_feed("1.0.0-rc.5", Some("http://evil.example/update"));
+        let stripped = evaluate_update(windows, &current, &unsafe_feed, false, None);
+        assert!(stripped.available);
+        assert!(stripped.release_url.is_none());
+    }
+
+    #[test]
+    fn checksum_helpers_accept_only_an_exact_digest() {
+        let digest = sha256_hex(b"rustfs");
+        assert_eq!(digest.len(), 64);
+        verify_sha256(&digest, &digest.to_ascii_uppercase(), "asset.zip").unwrap();
+
+        let error = verify_sha256(&digest, &"a".repeat(64), "asset.zip").unwrap_err();
+        assert!(matches!(error, Error::ChecksumMismatch { .. }));
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob");
+        std::fs::write(&path, b"rustfs").unwrap();
+        assert_eq!(hash_file(&path).unwrap(), digest);
+    }
+
+    fn compile_stub(dir: &std::path::Path, source: &str, name: &str) -> std::path::PathBuf {
+        let src = dir.join(format!("{name}.rs"));
+        std::fs::write(&src, source).unwrap();
+        let exe = dir.join(format!("{name}{}", std::env::consts::EXE_SUFFIX));
+        let status = Command::new("rustc")
+            .arg(&src)
+            .arg("-o")
+            .arg(&exe)
+            .status()
+            .expect("rustc should be available");
+        assert!(status.success(), "failed to compile {name}");
+        exe
+    }
+
+    #[test]
+    fn smoke_test_accepts_a_working_binary_and_rejects_failures() {
+        let dir = tempfile::tempdir().unwrap();
+        let ok = compile_stub(
+            dir.path(),
+            r#"fn main() { if std::env::args().any(|a| a == "--version") { println!("rustfs 1.2.3"); } }"#,
+            "ok",
+        );
+        assert_eq!(smoke_test(&ok).unwrap(), "rustfs 1.2.3");
+
+        let fail = compile_stub(
+            dir.path(),
+            r#"fn main() { std::process::exit(2); }"#,
+            "fail",
+        );
+        let error = smoke_test(&fail).unwrap_err();
+        assert!(error.to_string().contains("exited"));
+
+        let missing = dir.path().join("missing-binary");
+        assert!(smoke_test(&missing).is_err());
+    }
+
+    #[test]
+    fn stage_update_does_not_leave_a_failed_binary_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("release.zip");
+        write_zip(&archive, &[("rustfs", b"not-an-executable")]);
+        let staged = dir.path().join("rustfs.staged");
+
+        assert!(stage_update(&archive, &staged, true).is_err());
+        assert!(!staged.exists());
+    }
+
+    #[test]
+    fn offline_install_then_launch_uses_the_committed_binary() {
+        crate::state::terminate_rustfs_process();
+
+        let dir = tempfile::tempdir().unwrap();
+        let stub = compile_stub(
+            dir.path(),
+            r#"
+                fn main() {
+                    if std::env::args().any(|a| a == "--version") {
+                        println!("rustfs 1.0.0-rc.4");
+                        return;
+                    }
+                    std::thread::sleep(std::time::Duration::from_secs(20));
+                }
+            "#,
+            "rustfs-stub",
+        );
+        let archive = dir.path().join("release.zip");
+        let binary_bytes = std::fs::read(&stub).unwrap();
+        write_zip(&archive, &[("rustfs", binary_bytes.as_slice())]);
+
+        let platform = Platform::from_target("macos", "aarch64").unwrap();
+        let managed = dir.path().join("managed");
+        std::fs::create_dir_all(&managed).unwrap();
+        let staged = managed.join(format!("{}.staged", platform.binary_name()));
+        let digest = hash_file(&archive).unwrap();
+
+        let reported = stage_update(&archive, &staged, true).unwrap();
+        assert!(reported.contains("1.0.0-rc.4"));
+
+        let message = commit_update(
+            platform,
+            "v1.0.0-rc.4",
+            "rustfs-macos-aarch64-v1.0.0-rc.4.zip",
+            &digest,
+            &staged,
+            &managed,
+            true,
+        )
+        .unwrap();
+        assert!(message.contains("1.0.0-rc.4"));
+        assert!(message.contains("stopped"));
+
+        let (installed, record) = installed_binary_from(&managed, Some("1.0.0-rc.3"))
+            .expect("install should be selected");
+        assert_eq!(record.version, "1.0.0-rc.4");
+        assert_eq!(
+            effective_version_from(Some(&managed), Some("1.0.0-rc.3")).version,
+            "1.0.0-rc.4"
+        );
+        assert!(version::prefer_installed(
+            &record.version,
+            Some("1.0.0-rc.3")
+        ));
+
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir(&data_dir).unwrap();
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        launch(crate::config::RustFsConfig {
+            binary_path: Some(installed.to_string_lossy().into_owned()),
+            data_path: data_dir.to_string_lossy().into_owned(),
+            port: Some(port),
+            console_enable: false,
+            host: Some("127.0.0.1".into()),
+            ..crate::config::RustFsConfig::default()
+        })
+        .expect("installed stub should launch");
+        assert!(crate::state::is_rustfs_process_running());
+        crate::state::terminate_rustfs_process();
+        assert!(!crate::state::is_rustfs_process_running());
+    }
+
+    #[test]
+    fn progress_events_advertise_a_stable_event_tag() {
+        let started = serde_json::to_value(Stage::Started {
+            asset: "rustfs-windows-x86_64-v1.0.0.zip".into(),
+            content_length: Some(10),
+        })
+        .unwrap();
+        assert_eq!(started["event"], "started");
+        assert_eq!(started["asset"], "rustfs-windows-x86_64-v1.0.0.zip");
+
+        let progress = serde_json::to_string(&Stage::Progress {
+            downloaded: 4,
+            content_length: Some(10),
+        })
+        .unwrap();
+        assert!(progress.contains("\"event\":\"progress\""));
+        assert!(progress.contains("contentLength") || progress.contains("content_length"));
+    }
+
+    #[test]
+    fn real_latest_json_fixture_evaluates_windows_and_macos() {
+        const FIXTURE: &str = r#"{
+          "version": "1.0.0-rc.4",
+          "tag": "1.0.0-rc.4",
+          "release_date": "2026-08-28T14:24:08Z",
+          "release_type": "prerelease",
+          "download_url": "https://github.com/rustfs/rustfs/releases/tag/1.0.0-rc.4"
+        }"#;
+        let feed = parse_latest_feed(FIXTURE).unwrap();
+        let current = EffectiveVersion {
+            version: "1.0.0-rc.3".to_string(),
+            managed: false,
+        };
+
+        let windows = evaluate_update(
+            Platform::from_target("windows", "aarch64").unwrap(),
+            &current,
+            &feed,
+            false,
+            Some(MANIFEST),
+        );
+        assert!(windows.available);
+        assert_eq!(
+            windows.asset_name.as_deref(),
+            Some("rustfs-windows-x86_64-v1.0.0-rc.4.zip")
+        );
+
+        let apple = evaluate_update(
+            Platform::from_target("macos", "aarch64").unwrap(),
+            &current,
+            &feed,
+            false,
+            Some(MANIFEST),
+        );
+        assert!(apple.available);
     }
 }

--- a/src-tauri/src/version.rs
+++ b/src-tauri/src/version.rs
@@ -1,0 +1,83 @@
+//! Helpers for comparing RustFS release tags.
+//!
+//! Upstream publishes tags such as `1.0.0-rc.4` while release assets embed a
+//! `v`-prefixed variant (`rustfs-macos-aarch64-v1.0.0-rc.4.zip`), so both forms
+//! have to round-trip cleanly.
+
+/// Drops a leading `v` so `v1.2.3` and `1.2.3` compare equal.
+pub fn normalize(tag: &str) -> &str {
+    let trimmed = tag.trim();
+    trimmed.strip_prefix('v').unwrap_or(trimmed)
+}
+
+/// Adds the leading `v` used by upstream asset file names.
+pub fn asset_version(tag: &str) -> String {
+    format!("v{}", normalize(tag))
+}
+
+fn parse(tag: &str) -> Option<semver::Version> {
+    semver::Version::parse(normalize(tag)).ok()
+}
+
+/// True when `candidate` is a strictly newer release than `current`.
+///
+/// Falls back to a plain inequality check when either tag is not valid semver,
+/// so an unparseable upstream tag still surfaces as an available update.
+pub fn is_newer(candidate: &str, current: &str) -> bool {
+    match (parse(candidate), parse(current)) {
+        (Some(candidate), Some(current)) => candidate > current,
+        _ => normalize(candidate) != normalize(current),
+    }
+}
+
+/// Decides whether a user-installed RustFS binary should win over the one
+/// bundled with the launcher. A launcher upgrade can ship a newer RustFS than
+/// the locally installed copy, in which case the bundle takes precedence.
+pub fn prefer_installed(installed: &str, bundled: Option<&str>) -> bool {
+    let Some(bundled) = bundled.map(str::trim).filter(|value| !value.is_empty()) else {
+        return true;
+    };
+
+    match (parse(installed), parse(bundled)) {
+        (Some(installed), Some(bundled)) => installed >= bundled,
+        // Without comparable versions, trust the explicit user action.
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{asset_version, is_newer, normalize, prefer_installed};
+
+    #[test]
+    fn normalizes_v_prefixed_tags() {
+        assert_eq!(normalize("v1.0.0-rc.4"), "1.0.0-rc.4");
+        assert_eq!(normalize(" 1.0.0 "), "1.0.0");
+        assert_eq!(asset_version("1.0.0-rc.4"), "v1.0.0-rc.4");
+        assert_eq!(asset_version("v1.0.0-rc.4"), "v1.0.0-rc.4");
+    }
+
+    #[test]
+    fn orders_prereleases_below_releases() {
+        assert!(is_newer("1.0.0", "1.0.0-rc.4"));
+        assert!(is_newer("1.0.0-rc.5", "1.0.0-rc.4"));
+        assert!(!is_newer("1.0.0-rc.4", "1.0.0-rc.4"));
+        assert!(!is_newer("v1.0.0-rc.4", "1.0.0-rc.4"));
+        assert!(!is_newer("1.0.0-rc.3", "1.0.0-rc.4"));
+    }
+
+    #[test]
+    fn treats_unparseable_tags_as_changed() {
+        assert!(is_newer("nightly-2026-08-28", "1.0.0"));
+        assert!(!is_newer("nightly", "nightly"));
+    }
+
+    #[test]
+    fn bundled_binary_wins_when_it_is_newer() {
+        assert!(prefer_installed("1.0.0-rc.4", Some("1.0.0-rc.3")));
+        assert!(prefer_installed("1.0.0-rc.4", Some("1.0.0-rc.4")));
+        assert!(!prefer_installed("1.0.0-rc.3", Some("1.0.0-rc.4")));
+        assert!(prefer_installed("1.0.0-rc.3", None));
+        assert!(prefer_installed("1.0.0-rc.3", Some("unknown")));
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,9 @@ use crate::components::config_form::ConfigForm;
 use crate::components::log_viewer::LogViewer;
 use crate::components::toast::{Toast, ToastMessage, ToastType};
 use crate::types::{
-    AppVersionInfo, CommandResponse, LogEntry, LogType, RuntimeStatus, RustFsConfig, UpdateInfo,
+    AppVersionInfo, CommandResponse, LogEntry, LogType, RuntimeStatus, RustFsConfig,
+    RustFsUpdateInfo, UpdateInfo, APP_LOG_CAPACITY, DEFAULT_API_PORT, DEFAULT_CONSOLE_PORT,
+    DEFAULT_HOST, RUSTFS_LOG_CAPACITY,
 };
 use leptos::ev::SubmitEvent;
 use leptos::prelude::*;
@@ -39,7 +41,7 @@ fn js_error_message(err: JsValue) -> String {
 
 fn display_host(host: Option<&str>) -> String {
     match host.map(str::trim).filter(|value| !value.is_empty()) {
-        Some("0.0.0.0") | Some("*") | None => "127.0.0.1".to_string(),
+        Some("0.0.0.0") | Some("*") | None => DEFAULT_HOST.to_string(),
         Some("::") | Some("[::]") => "[::1]".to_string(),
         Some(host) if host.contains(':') && !host.starts_with('[') => format!("[{host}]"),
         Some(host) => host.to_string(),
@@ -52,6 +54,53 @@ fn is_tauri() -> bool {
         .and_then(|w| js_sys::Reflect::get(&w, &"__TAURI__".into()).ok())
         .map(|v| !v.is_undefined())
         .unwrap_or(false)
+}
+
+fn set_js_field(object: &js_sys::Object, key: &str, value: impl Into<JsValue>) {
+    let _ = js_sys::Reflect::set(object, &JsValue::from_str(key), &value.into());
+}
+
+fn empty_args() -> JsValue {
+    js_sys::Object::new().into()
+}
+
+fn confirm_action(message: &str) -> bool {
+    web_sys::window()
+        .and_then(|window| window.confirm_with_message(message).ok())
+        .unwrap_or(false)
+}
+
+fn js_f64(payload: &JsValue, keys: &[&str]) -> Option<f64> {
+    keys.iter().find_map(|key| {
+        js_sys::Reflect::get(payload, &JsValue::from_str(key))
+            .ok()
+            .and_then(|value| value.as_f64())
+            .filter(|value| value.is_finite())
+    })
+}
+
+fn apply_progress_payload(payload: &JsValue, set_progress: WriteSignal<Option<u32>>) {
+    let event_name = js_sys::Reflect::get(payload, &"event".into())
+        .ok()
+        .and_then(|value| value.as_string());
+
+    match event_name.as_deref() {
+        Some("started") => set_progress.set(Some(0)),
+        Some("progress") => {
+            let downloaded = js_f64(payload, &["downloaded"]);
+            if let Some(downloaded) = downloaded {
+                let percent = js_f64(payload, &["content_length", "contentLength"])
+                    .filter(|total| *total > 0.0)
+                    .map(|total| ((downloaded / total) * 100.0).min(99.0) as u32);
+                if percent.is_some() {
+                    set_progress.set(percent);
+                }
+            }
+        }
+        Some("verifying") => set_progress.set(Some(99)),
+        Some("installing") | Some("finished") => set_progress.set(Some(100)),
+        _ => {}
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -123,13 +172,10 @@ fn describe_config(config: &RustFsConfig) -> String {
     )
 }
 
-const APP_LOG_CAPACITY: usize = 100;
-const RUSTFS_LOG_CAPACITY: usize = 1000;
-const DEFAULT_RUSTFS_PORT: u16 = 9000;
-const DEFAULT_CONSOLE_PORT: u16 = 9001;
 const CONSOLE_UI_PATH: &str = "/rustfs/console/";
 static NEXT_LOG_ID: AtomicU64 = AtomicU64::new(1);
 static HEALTH_CHECK_STARTED: AtomicBool = AtomicBool::new(false);
+static UPDATE_CHECK_STARTED: AtomicBool = AtomicBool::new(false);
 
 fn next_log_id() -> u64 {
     NEXT_LOG_ID.fetch_add(1, Ordering::Relaxed)
@@ -166,12 +212,12 @@ fn sync_runtime_status(
         }
 
         let current = config.get_untracked();
-        let host = current.host.unwrap_or_else(|| "127.0.0.1".to_string());
-        let port = current.port.unwrap_or(DEFAULT_RUSTFS_PORT);
+        let host = current.host.unwrap_or_else(|| DEFAULT_HOST.to_string());
+        let port = current.port.unwrap_or(DEFAULT_API_PORT);
 
         let status_args = js_sys::Object::new();
-        js_sys::Reflect::set(&status_args, &"host".into(), &host.into()).unwrap();
-        js_sys::Reflect::set(&status_args, &"port".into(), &port.into()).unwrap();
+        set_js_field(&status_args, "host", host);
+        set_js_field(&status_args, "port", port);
 
         let (managed_running, service_online) =
             match tauri_invoke("get_runtime_status", status_args.into()).await {
@@ -204,9 +250,12 @@ pub fn App() -> impl IntoView {
     let (can_stop, set_can_stop) = signal(false);
     let (version_info, set_version_info) = signal(None::<AppVersionInfo>);
     let (update_info, set_update_info) = signal(None::<UpdateInfo>);
+    let (rustfs_update_info, set_rustfs_update_info) = signal(None::<RustFsUpdateInfo>);
     let (is_checking_update, set_is_checking_update) = signal(false);
     let (is_installing_update, set_is_installing_update) = signal(false);
+    let (is_installing_rustfs, set_is_installing_rustfs) = signal(false);
     let (update_progress, set_update_progress) = signal(None::<u32>);
+    let (rustfs_update_progress, set_rustfs_update_progress) = signal(None::<u32>);
 
     let remove_toast = Callback::new(move |id: u64| {
         set_toasts.update(|current| {
@@ -224,16 +273,16 @@ pub fn App() -> impl IntoView {
             });
         });
 
-        // Auto remove after 3 seconds
-        let _ = web_sys::window()
-            .unwrap()
-            .set_timeout_with_callback_and_timeout_and_arguments_0(
-                Closure::once_into_js(move || {
-                    remove_toast.run(id);
-                })
-                .unchecked_ref(),
-                3000,
-            );
+        let Some(window) = web_sys::window() else {
+            return;
+        };
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+            Closure::once_into_js(move || {
+                remove_toast.run(id);
+            })
+            .unchecked_ref(),
+            3000,
+        );
     };
 
     Effect::new(move |_| {
@@ -333,30 +382,13 @@ pub fn App() -> impl IntoView {
                 let Ok(payload) = js_sys::Reflect::get(&event, &"payload".into()) else {
                     return;
                 };
-                let event_name = js_sys::Reflect::get(&payload, &"event".into())
-                    .ok()
-                    .and_then(|value| value.as_string());
-
-                match event_name.as_deref() {
-                    Some("started") => set_update_progress.set(Some(0)),
-                    Some("progress") => {
-                        let downloaded = js_sys::Reflect::get(&payload, &"downloaded".into())
-                            .ok()
-                            .and_then(|value| value.as_f64());
-                        if let Some(downloaded) = downloaded {
-                            let percent = js_sys::Reflect::get(&payload, &"content_length".into())
-                                .ok()
-                                .and_then(|value| value.as_f64())
-                                .filter(|total| *total > 0.0)
-                                .map(|total| ((downloaded / total) * 100.0).min(100.0) as u32);
-                            if percent.is_some() {
-                                set_update_progress.set(percent);
-                            }
-                        }
-                    }
-                    Some("finished") => set_update_progress.set(Some(100)),
-                    _ => {}
-                }
+                apply_progress_payload(&payload, set_update_progress);
+            }) as Box<dyn FnMut(JsValue)>);
+            let rustfs_update_listener = Closure::wrap(Box::new(move |event: JsValue| {
+                let Ok(payload) = js_sys::Reflect::get(&event, &"payload".into()) else {
+                    return;
+                };
+                apply_progress_payload(&payload, set_rustfs_update_progress);
             }) as Box<dyn FnMut(JsValue)>);
 
             if let Ok(tauri) = js_sys::Reflect::get(&window, &"__TAURI__".into()) {
@@ -384,6 +416,11 @@ pub fn App() -> impl IntoView {
                             &"update-progress".into(),
                             update_listener.as_ref().unchecked_ref(),
                         );
+                        let _ = listen_fn.call2(
+                            &event,
+                            &"rustfs-update-progress".into(),
+                            rustfs_update_listener.as_ref().unchecked_ref(),
+                        );
                     }
                 }
             }
@@ -392,6 +429,7 @@ pub fn App() -> impl IntoView {
             rustfs_listener.forget();
             exit_listener.forget();
             update_listener.forget();
+            rustfs_update_listener.forget();
         }
 
         if let Ok(app_logs_value) = tauri_invoke("get_app_logs", js_sys::Object::new().into()).await
@@ -451,7 +489,6 @@ pub fn App() -> impl IntoView {
 
             let current_config = config.get_untracked();
 
-            // 添加详细日志
             leptos::logging::log!(
                 "Starting RustFS with config: data_path={}, port={:?}, host={:?}",
                 current_config.data_path,
@@ -468,11 +505,11 @@ pub fn App() -> impl IntoView {
 
             // Create args object with config parameter
             let args = js_sys::Object::new();
-            let config_js = serde_wasm_bindgen::to_value(&current_config).unwrap();
-            js_sys::Reflect::set(&args, &"config".into(), &config_js).unwrap();
+            let config_js = serde_wasm_bindgen::to_value(&current_config).unwrap_or(JsValue::NULL);
+            set_js_field(&args, "config", config_js.clone());
 
             let validate_args = js_sys::Object::new();
-            js_sys::Reflect::set(&validate_args, &"config".into(), &config_js).unwrap();
+            set_js_field(&validate_args, "config", config_js);
             if let Err(err) = tauri_invoke("validate_config", validate_args.into()).await {
                 let message = js_error_message(err);
                 show_toast(message.clone(), ToastType::Error);
@@ -608,54 +645,116 @@ pub fn App() -> impl IntoView {
         });
     };
 
-    let check_update = move |_| {
-        if !is_tauri() || is_checking_update.get_untracked() || is_installing_update.get_untracked()
+    let updates_busy = move || {
+        is_checking_update.get() || is_installing_update.get() || is_installing_rustfs.get()
+    };
+
+    let run_update_checks = move |notify: bool| {
+        if !is_tauri()
+            || is_checking_update.get_untracked()
+            || is_installing_update.get_untracked()
+            || is_installing_rustfs.get_untracked()
         {
             return;
         }
 
         set_is_checking_update.set(true);
-        set_update_info.set(None);
         spawn_local(async move {
-            match tauri_invoke("check_for_update", js_sys::Object::new().into()).await {
+            let mut found = Vec::<String>::new();
+
+            match tauri_invoke("check_for_update", empty_args()).await {
                 Ok(result) => match serde_wasm_bindgen::from_value::<UpdateInfo>(result) {
                     Ok(info) => {
                         if info.available {
-                            show_toast(
-                                format!(
-                                    "Update available: {}",
-                                    info.version.as_deref().unwrap_or("unknown")
-                                ),
-                                ToastType::Success,
-                            );
-                        } else {
-                            show_toast(
-                                "You are running the latest version".to_string(),
-                                ToastType::Success,
-                            );
+                            found.push(format!(
+                                "Launcher {}",
+                                info.version.as_deref().unwrap_or("unknown")
+                            ));
                         }
                         set_update_info.set(Some(info));
                     }
                     Err(_) => {
-                        show_toast(
-                            "Update check failed. See App Logs for details.".to_string(),
-                            ToastType::Error,
-                        );
+                        let message = "Launcher update check failed. See App Logs for details.";
+                        push_log(set_app_logs, format!("[ERROR] {message}"), APP_LOG_CAPACITY);
+                        if notify {
+                            show_toast(message.to_string(), ToastType::Error);
+                        }
                     }
                 },
                 Err(err) => {
-                    show_toast(
-                        format!("Update check failed: {}", js_error_message(err)),
-                        ToastType::Error,
-                    );
+                    let message =
+                        format!("Launcher update check failed: {}", js_error_message(err));
+                    push_log(set_app_logs, format!("[ERROR] {message}"), APP_LOG_CAPACITY);
+                    if notify {
+                        show_toast(message, ToastType::Error);
+                    }
                 }
             }
+
+            match tauri_invoke("check_rustfs_update", empty_args()).await {
+                Ok(result) => match serde_wasm_bindgen::from_value::<RustFsUpdateInfo>(result) {
+                    Ok(info) => {
+                        if info.available {
+                            found.push(format!(
+                                "RustFS {}",
+                                info.latest_version.as_deref().unwrap_or("unknown")
+                            ));
+                        }
+                        set_rustfs_update_info.set(Some(info));
+                    }
+                    Err(_) => {
+                        let message = "RustFS update check failed. See App Logs for details.";
+                        push_log(set_app_logs, format!("[ERROR] {message}"), APP_LOG_CAPACITY);
+                        if notify {
+                            show_toast(message.to_string(), ToastType::Error);
+                        }
+                    }
+                },
+                Err(err) => {
+                    let message = format!("RustFS update check failed: {}", js_error_message(err));
+                    push_log(set_app_logs, format!("[ERROR] {message}"), APP_LOG_CAPACITY);
+                    if notify {
+                        show_toast(message, ToastType::Error);
+                    }
+                }
+            }
+
+            if notify {
+                if found.is_empty() {
+                    show_toast(
+                        "You are running the latest versions".to_string(),
+                        ToastType::Success,
+                    );
+                } else {
+                    show_toast(
+                        format!("Update available: {}", found.join(" · ")),
+                        ToastType::Success,
+                    );
+                }
+            } else if !found.is_empty() {
+                show_toast(
+                    format!("Update available: {}", found.join(" · ")),
+                    ToastType::Info,
+                );
+            }
+
             set_is_checking_update.set(false);
         });
     };
 
+    Effect::new(move |_| {
+        if !is_tauri() || UPDATE_CHECK_STARTED.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        run_update_checks(false);
+    });
+
+    let check_update = move |_| {
+        run_update_checks(true);
+    };
+
     let install_update = move |_| {
-        if is_installing_update.get_untracked() {
+        if is_installing_update.get_untracked() || is_installing_rustfs.get_untracked() {
             return;
         }
 
@@ -663,35 +762,28 @@ pub fn App() -> impl IntoView {
             .get_untracked()
             .map(|info| info.rustfs_running)
             .unwrap_or(false);
-        if rustfs_running {
-            let confirmed = web_sys::window()
-                .and_then(|window| {
-                    window
-                        .confirm_with_message(
-                            "Updating stops the RustFS service managed by this launcher and restarts the launcher once the update is installed. Continue?",
-                        )
-                        .ok()
-                })
-                .unwrap_or(false);
-            if !confirmed {
-                return;
-            }
+        if rustfs_running
+            && !confirm_action(
+                "Updating the launcher stops the RustFS service it manages and restarts the app once the update is installed. Continue?",
+            )
+        {
+            return;
         }
 
         set_is_installing_update.set(true);
         set_update_progress.set(Some(0));
         show_toast(
-            "Downloading and installing the update…".to_string(),
+            "Downloading and installing the launcher update…".to_string(),
             ToastType::Info,
         );
         spawn_local(async move {
-            match tauri_invoke("install_update", js_sys::Object::new().into()).await {
+            match tauri_invoke("install_update", empty_args()).await {
                 Ok(result) => {
                     if serde_wasm_bindgen::from_value::<CommandResponse>(result).is_err() {
                         set_is_installing_update.set(false);
                         set_update_progress.set(None);
                         show_toast(
-                            "Update installation failed. See App Logs for details.".to_string(),
+                            "Launcher update failed. See App Logs for details.".to_string(),
                             ToastType::Error,
                         );
                     }
@@ -699,12 +791,83 @@ pub fn App() -> impl IntoView {
                 Err(err) => {
                     set_is_installing_update.set(false);
                     set_update_progress.set(None);
-                    show_toast(
-                        format!("Update installation failed: {}", js_error_message(err)),
-                        ToastType::Error,
-                    );
+                    let message = format!("Launcher update failed: {}", js_error_message(err));
+                    push_log(set_app_logs, format!("[ERROR] {message}"), APP_LOG_CAPACITY);
+                    show_toast(message, ToastType::Error);
                 }
             }
+        });
+    };
+
+    let install_rustfs_update = move |_| {
+        if is_installing_update.get_untracked() || is_installing_rustfs.get_untracked() {
+            return;
+        }
+
+        let rustfs_running = rustfs_update_info
+            .get_untracked()
+            .map(|info| info.rustfs_running)
+            .unwrap_or(false);
+        if rustfs_running
+            && !confirm_action(
+                "Updating RustFS stops the service managed by this launcher. Launch it again afterwards to use the new build. Continue?",
+            )
+        {
+            return;
+        }
+
+        set_is_installing_rustfs.set(true);
+        set_rustfs_update_progress.set(Some(0));
+        show_toast(
+            "Downloading and installing the RustFS update…".to_string(),
+            ToastType::Info,
+        );
+        spawn_local(async move {
+            match tauri_invoke("install_rustfs_update", empty_args()).await {
+                Ok(result) => match serde_wasm_bindgen::from_value::<CommandResponse>(result) {
+                    Ok(response) => {
+                        show_toast(response.message.clone(), ToastType::Success);
+                        push_log(set_app_logs, response.message, APP_LOG_CAPACITY);
+                        if let Ok(version_value) =
+                            tauri_invoke("get_app_version_info", empty_args()).await
+                        {
+                            if let Ok(info) =
+                                serde_wasm_bindgen::from_value::<AppVersionInfo>(version_value)
+                            {
+                                set_version_info.set(Some(info));
+                            }
+                        }
+                        if let Ok(check_value) =
+                            tauri_invoke("check_rustfs_update", empty_args()).await
+                        {
+                            if let Ok(info) =
+                                serde_wasm_bindgen::from_value::<RustFsUpdateInfo>(check_value)
+                            {
+                                set_rustfs_update_info.set(Some(info));
+                            }
+                        }
+                        sync_runtime_status(
+                            config,
+                            set_is_running,
+                            set_can_stop,
+                            set_service_status,
+                        );
+                    }
+                    Err(_) => {
+                        show_toast(
+                            "RustFS update failed. See App Logs for details.".to_string(),
+                            ToastType::Error,
+                        );
+                    }
+                },
+                Err(err) => {
+                    let message = format!("RustFS update failed: {}", js_error_message(err));
+                    push_log(set_app_logs, format!("[ERROR] {message}"), APP_LOG_CAPACITY);
+                    show_toast(message, ToastType::Error);
+                }
+            }
+            set_is_installing_rustfs.set(false);
+            set_rustfs_update_progress.set(None);
         });
     };
 
@@ -715,7 +878,7 @@ pub fn App() -> impl IntoView {
 
         spawn_local(async move {
             let args = js_sys::Object::new();
-            js_sys::Reflect::set(&args, &"url".into(), &JsValue::from_str(&url)).unwrap();
+            set_js_field(&args, "url", JsValue::from_str(&url));
             if let Err(err) = tauri_invoke("open_service_url", args.into()).await {
                 show_toast(js_error_message(err), ToastType::Error);
             }
@@ -728,7 +891,7 @@ pub fn App() -> impl IntoView {
         let url = format!(
             "http://{}:{}",
             host,
-            current.port.unwrap_or(DEFAULT_RUSTFS_PORT)
+            current.port.unwrap_or(DEFAULT_API_PORT)
         );
         open_service_url(url);
     };
@@ -757,7 +920,7 @@ pub fn App() -> impl IntoView {
                     <span class="eyebrow">"Control Plane"</span>
                     <h1>"RustFS Launcher"</h1>
 
-                    <div class="status-cluster">
+                    <div class="status-cluster" role="status" aria-live="polite">
                         <div class="service-indicator" class:online=move || service_status.get()>
                             <span class="status-dot"></span>
                             <span class="status-text">
@@ -786,7 +949,7 @@ pub fn App() -> impl IntoView {
                         on:click=open_api
                     >
                         <span class="summary-label">"API"</span>
-                        <strong>{move || format!(":{}", config.get().port.unwrap_or(DEFAULT_RUSTFS_PORT))}</strong>
+                        <strong>{move || format!(":{}", config.get().port.unwrap_or(DEFAULT_API_PORT))}</strong>
                     </button>
                     <button
                         type="button"
@@ -821,22 +984,40 @@ pub fn App() -> impl IntoView {
                         <button
                             type="button"
                             class="update-check-btn"
-                            disabled=move || is_checking_update.get() || is_installing_update.get()
+                            disabled=updates_busy
                             on:click=check_update
                         >
                             {move || if is_checking_update.get() { "Checking…" } else { "Check for Updates" }}
                         </button>
                     </div>
 
+                    <p class="update-platform">
+                        {move || version_info
+                            .get()
+                            .map(|info| info.platform)
+                            .unwrap_or_else(|| "Windows / macOS".to_string())}
+                    </p>
+
                     <div class="version-row">
                         <span>{move || format!(
                             "Launcher {}",
                             version_info.get().map(|info| info.launcher_version).unwrap_or_else(|| "—".to_string())
                         )}</span>
-                        <span>{move || format!(
-                            "RustFS {}",
-                            version_info.get().map(|info| info.rustfs_version).unwrap_or_else(|| "—".to_string())
-                        )}</span>
+                        <span>{move || {
+                            let info = version_info.get();
+                            let version = info
+                                .as_ref()
+                                .map(|info| info.rustfs_version.as_str())
+                                .unwrap_or("—");
+                            let source = info.as_ref().map(|info| {
+                                if info.rustfs_managed {
+                                    "installed"
+                                } else {
+                                    "bundled"
+                                }
+                            }).unwrap_or("bundled");
+                            format!("RustFS {version} ({source})")
+                        }}</span>
                     </div>
 
                     {move || update_info.get().map(|info| {
@@ -846,29 +1027,68 @@ pub fn App() -> impl IntoView {
                             view! {
                                 <div class="update-available">
                                     <div>
-                                        <strong>{format!("Update to {}", version)}</strong>
+                                        <strong>{format!("Launcher {}", version)}</strong>
                                         <p>{notes}</p>
                                     </div>
                                     <button
                                         type="button"
                                         class="update-install-btn"
-                                        disabled=move || is_installing_update.get()
+                                        disabled=updates_busy
                                         on:click=install_update
                                     >
-                                        {move || if is_installing_update.get() { "Installing…" } else { "Update Now" }}
+                                        {move || if is_installing_update.get() { "Installing…" } else { "Update Launcher" }}
                                     </button>
                                 </div>
                             }.into_any()
                         } else {
-                            view! { <p class="update-current">"You are running the latest version."</p> }.into_any()
+                            view! { <p class="update-current">"Launcher is up to date."</p> }.into_any()
+                        }
+                    })}
+
+                    {move || rustfs_update_info.get().map(|info| {
+                        if info.available {
+                            let version = info.latest_version.unwrap_or_else(|| "unknown".to_string());
+                            let detail = match (info.release_type, info.asset_name) {
+                                (Some(kind), Some(asset)) => format!("{kind} · {asset}"),
+                                (Some(kind), None) => kind,
+                                (None, Some(asset)) => asset,
+                                (None, None) => "Verified download from the RustFS release feed.".to_string(),
+                            };
+                            view! {
+                                <div class="update-available">
+                                    <div>
+                                        <strong>{format!("RustFS {}", version)}</strong>
+                                        <p>{detail}</p>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        class="update-install-btn"
+                                        disabled=updates_busy
+                                        on:click=install_rustfs_update
+                                    >
+                                        {move || if is_installing_rustfs.get() { "Installing…" } else { "Update RustFS" }}
+                                    </button>
+                                </div>
+                            }.into_any()
+                        } else {
+                            view! { <p class="update-current">"RustFS is up to date."</p> }.into_any()
                         }
                     })}
 
                     {move || is_installing_update.get().then(|| view! {
-                        <div class="update-progress">
+                        <div class="update-progress" aria-label="Launcher update progress">
                             <div
                                 class="update-progress-bar"
                                 style:width=move || format!("{}%", update_progress.get().unwrap_or(8))
+                            ></div>
+                        </div>
+                    })}
+
+                    {move || is_installing_rustfs.get().then(|| view! {
+                        <div class="update-progress" aria-label="RustFS update progress">
+                            <div
+                                class="update-progress-bar"
+                                style:width=move || format!("{}%", rustfs_update_progress.get().unwrap_or(8))
                             ></div>
                         </div>
                     })}

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,7 @@
 use crate::components::config_form::ConfigForm;
 use crate::components::log_viewer::LogViewer;
 use crate::components::toast::{Toast, ToastMessage, ToastType};
+use crate::helpers::{display_host, progress_percent, rustfs_idle_message, rustfs_source_label};
 use crate::types::{
     AppVersionInfo, CommandResponse, LogEntry, LogType, RuntimeStatus, RustFsConfig,
     RustFsUpdateInfo, UpdateInfo, APP_LOG_CAPACITY, DEFAULT_API_PORT, DEFAULT_CONSOLE_PORT,
@@ -37,15 +38,6 @@ fn js_error_message(err: JsValue) -> String {
     }
 
     format!("{err:?}")
-}
-
-fn display_host(host: Option<&str>) -> String {
-    match host.map(str::trim).filter(|value| !value.is_empty()) {
-        Some("0.0.0.0") | Some("*") | None => DEFAULT_HOST.to_string(),
-        Some("::") | Some("[::]") => "[::1]".to_string(),
-        Some(host) if host.contains(':') && !host.starts_with('[') => format!("[{host}]"),
-        Some(host) => host.to_string(),
-    }
 }
 
 // Helper function to check if we're in Tauri environment
@@ -89,9 +81,10 @@ fn apply_progress_payload(payload: &JsValue, set_progress: WriteSignal<Option<u3
         Some("progress") => {
             let downloaded = js_f64(payload, &["downloaded"]);
             if let Some(downloaded) = downloaded {
-                let percent = js_f64(payload, &["content_length", "contentLength"])
-                    .filter(|total| *total > 0.0)
-                    .map(|total| ((downloaded / total) * 100.0).min(99.0) as u32);
+                let percent = progress_percent(
+                    downloaded,
+                    js_f64(payload, &["content_length", "contentLength"]),
+                );
                 if percent.is_some() {
                     set_progress.set(percent);
                 }
@@ -1009,13 +1002,10 @@ pub fn App() -> impl IntoView {
                                 .as_ref()
                                 .map(|info| info.rustfs_version.as_str())
                                 .unwrap_or("—");
-                            let source = info.as_ref().map(|info| {
-                                if info.rustfs_managed {
-                                    "installed"
-                                } else {
-                                    "bundled"
-                                }
-                            }).unwrap_or("bundled");
+                            let source = info
+                                .as_ref()
+                                .map(|info| rustfs_source_label(info.rustfs_managed))
+                                .unwrap_or("bundled");
                             format!("RustFS {version} ({source})")
                         }}</span>
                     </div>
@@ -1071,7 +1061,7 @@ pub fn App() -> impl IntoView {
                                 </div>
                             }.into_any()
                         } else {
-                            view! { <p class="update-current">"RustFS is up to date."</p> }.into_any()
+                            view! { <p class="update-current">{rustfs_idle_message(info.notes.as_deref())}</p> }.into_any()
                         }
                     })}
 

--- a/src/components/config_form.rs
+++ b/src/components/config_form.rs
@@ -1,4 +1,4 @@
-use crate::types::RustFsConfig;
+use crate::types::{RustFsConfig, DEFAULT_API_PORT, DEFAULT_CONSOLE_PORT, DEFAULT_HOST};
 use leptos::ev::SubmitEvent;
 use leptos::prelude::*;
 use serde_json;
@@ -17,8 +17,6 @@ extern "C" {
 const API_PORT_ERROR_MESSAGE: &str = "API port must be a number between 1 and 65535";
 const CONSOLE_PORT_ERROR_MESSAGE: &str = "Console port must be a number between 1 and 65535";
 const PORT_CONFLICT_ERROR_MESSAGE: &str = "API port and console port must be different";
-const DEFAULT_API_PORT: u16 = 9000;
-const DEFAULT_CONSOLE_PORT: u16 = 9001;
 
 fn extract_dropped_paths(payload: &JsValue) -> Vec<String> {
     if let Ok(paths) = js_sys::Reflect::get(payload, &"paths".into()) {
@@ -440,7 +438,7 @@ pub fn ConfigForm(
                                         let current = config.get();
                                         format!(
                                             "{}:{}",
-                                            current.host.unwrap_or_else(|| "127.0.0.1".to_string()),
+                                            current.host.unwrap_or_else(|| DEFAULT_HOST.to_string()),
                                             current.console_port.unwrap_or(DEFAULT_CONSOLE_PORT)
                                         )
                                     }}
@@ -491,6 +489,14 @@ pub fn ConfigForm(
                                     type="button"
                                     class="toggle-visibility"
                                     disabled=move || is_running.get()
+                                    aria-pressed=move || show_secret.get()
+                                    aria-label=move || {
+                                        if show_secret.get() {
+                                            "Hide secret key"
+                                        } else {
+                                            "Show secret key"
+                                        }
+                                    }
                                     on:click=move |_| {
                                         if !is_running.get() {
                                             set_show_secret.update(|show| *show = !*show);

--- a/src/components/log_viewer.rs
+++ b/src/components/log_viewer.rs
@@ -37,10 +37,12 @@ pub fn LogViewer(
     view! {
         <div class="log-panel">
             <div class="log-header">
-                <div class="log-tabs">
+                <div class="log-tabs" role="tablist" aria-label="Log sources">
                     <button
                         class="log-tab"
                         class:active=move || current_log_type.get() == LogType::App
+                        role="tab"
+                        aria-selected=move || current_log_type.get() == LogType::App
                         on:click=move |_| set_current_log_type.set(LogType::App)
                     >
                         "App Logs"
@@ -48,6 +50,8 @@ pub fn LogViewer(
                     <button
                         class="log-tab"
                         class:active=move || current_log_type.get() == LogType::RustFS
+                        role="tab"
+                        aria-selected=move || current_log_type.get() == LogType::RustFS
                         on:click=move |_| set_current_log_type.set(LogType::RustFS)
                     >
                         "RustFS Output"

--- a/src/components/toast.rs
+++ b/src/components/toast.rs
@@ -20,7 +20,7 @@ pub fn Toast(
     #[prop(into)] remove_toast: Callback<u64>,
 ) -> impl IntoView {
     view! {
-        <div class="toast-container">
+        <div class="toast-container" role="status" aria-live="polite" aria-atomic="true">
             <For
                 each=move || toasts.get()
                 key=|toast| toast.id
@@ -45,7 +45,11 @@ pub fn Toast(
                         }}
                     </span>
                     <span class="toast-text">{toast.message}</span>
-                    <button class="toast-close" on:click=move |_| remove_toast.run(toast.id)>
+                    <button
+                        class="toast-close"
+                        aria-label="Dismiss notification"
+                        on:click=move |_| remove_toast.run(toast.id)
+                    >
                         "×"
                     </button>
                 </div>

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,78 @@
+use crate::types::DEFAULT_HOST;
+
+/// Host shown on the API/Console cards. Wildcards become a loopback address
+/// the user's browser can actually open.
+pub fn display_host(host: Option<&str>) -> String {
+    match host.map(str::trim).filter(|value| !value.is_empty()) {
+        Some("0.0.0.0") | Some("*") | None => DEFAULT_HOST.to_string(),
+        Some("::") | Some("[::]") => "[::1]".to_string(),
+        Some(host) if host.contains(':') && !host.starts_with('[') => format!("[{host}]"),
+        Some(host) => host.to_string(),
+    }
+}
+
+pub fn rustfs_source_label(managed: bool) -> &'static str {
+    if managed {
+        "installed"
+    } else {
+        "bundled"
+    }
+}
+
+pub fn rustfs_idle_message(notes: Option<&str>) -> String {
+    notes
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("RustFS is up to date.")
+        .to_string()
+}
+
+/// Percent for the update progress bar. Accepts both the camelCase fields
+/// emitted by serde and the snake_case names the older listener used.
+pub fn progress_percent(downloaded: f64, content_length: Option<f64>) -> Option<u32> {
+    let total = content_length.filter(|total| *total > 0.0)?;
+    if !downloaded.is_finite() || downloaded < 0.0 {
+        return None;
+    }
+    Some(((downloaded / total) * 100.0).min(99.0) as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{display_host, progress_percent, rustfs_idle_message, rustfs_source_label};
+
+    #[test]
+    fn display_host_rewrites_wildcards_and_wraps_ipv6() {
+        assert_eq!(display_host(None), "127.0.0.1");
+        assert_eq!(display_host(Some("")), "127.0.0.1");
+        assert_eq!(display_host(Some("0.0.0.0")), "127.0.0.1");
+        assert_eq!(display_host(Some("*")), "127.0.0.1");
+        assert_eq!(display_host(Some("::")), "[::1]");
+        assert_eq!(display_host(Some("[::]")), "[::1]");
+        assert_eq!(display_host(Some("2001:db8::1")), "[2001:db8::1]");
+        assert_eq!(display_host(Some("[::1]")), "[::1]");
+        assert_eq!(display_host(Some("192.168.1.9")), "192.168.1.9");
+    }
+
+    #[test]
+    fn rustfs_labels_describe_the_binary_in_use() {
+        assert_eq!(rustfs_source_label(true), "installed");
+        assert_eq!(rustfs_source_label(false), "bundled");
+        assert_eq!(
+            rustfs_idle_message(Some("RustFS 1.0.0-rc.4 has no macOS (Intel) build.")),
+            "RustFS 1.0.0-rc.4 has no macOS (Intel) build."
+        );
+        assert_eq!(rustfs_idle_message(Some("  ")), "RustFS is up to date.");
+        assert_eq!(rustfs_idle_message(None), "RustFS is up to date.");
+    }
+
+    #[test]
+    fn progress_percent_caps_below_one_hundred_until_finished() {
+        assert_eq!(progress_percent(0.0, Some(100.0)), Some(0));
+        assert_eq!(progress_percent(50.0, Some(100.0)), Some(50));
+        assert_eq!(progress_percent(100.0, Some(100.0)), Some(99));
+        assert_eq!(progress_percent(10.0, Some(0.0)), None);
+        assert_eq!(progress_percent(10.0, None), None);
+        assert_eq!(progress_percent(f64::NAN, Some(100.0)), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod components;
+mod helpers;
 mod types;
 
 use app::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,17 @@
 use serde::{Deserialize, Serialize};
 
+/// Defaults mirrored from `src-tauri/src/config.rs` so the form shows the same
+/// values the backend falls back to.
+pub const DEFAULT_API_PORT: u16 = 9000;
+pub const DEFAULT_CONSOLE_PORT: u16 = 9001;
+pub const DEFAULT_HOST: &str = "127.0.0.1";
+pub const DEFAULT_ACCESS_KEY: &str = "rustfsadmin";
+pub const DEFAULT_SECRET_KEY: &str = "rustfsadmin";
+
+/// Log buffer sizes, matching the backend ring buffers in `state.rs`.
+pub const APP_LOG_CAPACITY: usize = 100;
+pub const RUSTFS_LOG_CAPACITY: usize = 1000;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct LogEntry {
     pub id: u64,
@@ -21,11 +33,11 @@ impl Default for RustFsConfig {
     fn default() -> Self {
         Self {
             data_path: String::new(),
-            port: Some(9000),
-            console_port: Some(9001),
-            host: Some("127.0.0.1".to_string()),
-            access_key: Some("rustfsadmin".to_string()),
-            secret_key: Some("rustfsadmin".to_string()),
+            port: Some(DEFAULT_API_PORT),
+            console_port: Some(DEFAULT_CONSOLE_PORT),
+            host: Some(DEFAULT_HOST.to_string()),
+            access_key: Some(DEFAULT_ACCESS_KEY.to_string()),
+            secret_key: Some(DEFAULT_SECRET_KEY.to_string()),
             console_enable: false,
         }
     }
@@ -46,9 +58,16 @@ pub struct CommandResponse {
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct AppVersionInfo {
     pub launcher_version: String,
+    /// Version of the RustFS binary the launcher will actually start.
     pub rustfs_version: String,
+    /// Version shipped inside the installer, when the build recorded one.
+    pub bundled_rustfs_version: Option<String>,
+    /// True when a user-installed RustFS binary takes precedence over the bundle.
+    pub rustfs_managed: bool,
+    pub platform: String,
 }
 
+/// Result of a launcher self-update check (tauri-plugin-updater).
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct UpdateInfo {
     pub available: bool,
@@ -56,6 +75,21 @@ pub struct UpdateInfo {
     pub version: Option<String>,
     pub notes: Option<String>,
     pub date: Option<String>,
+    pub rustfs_running: bool,
+}
+
+/// Result of a RustFS binary update check against the upstream release feed.
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct RustFsUpdateInfo {
+    pub available: bool,
+    pub current_version: String,
+    pub current_managed: bool,
+    pub latest_version: Option<String>,
+    pub release_date: Option<String>,
+    pub release_type: Option<String>,
+    pub release_url: Option<String>,
+    pub asset_name: Option<String>,
+    pub platform: String,
     pub rustfs_running: bool,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -89,6 +89,8 @@ pub struct RustFsUpdateInfo {
     pub release_type: Option<String>,
     pub release_url: Option<String>,
     pub asset_name: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
     pub platform: String,
     pub rustfs_running: bool,
 }

--- a/styles.css
+++ b/styles.css
@@ -259,9 +259,18 @@ button.summary-card.clickable:hover {
 
 .version-row {
   justify-content: flex-start;
+  flex-wrap: wrap;
   margin-top: 12px;
   color: var(--text-muted);
   font-size: 0.78rem;
+}
+
+.update-platform {
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .update-check-btn,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The launcher could start and stop RustFS, and it already had a **signed whole-app self-update**. Three gaps remained:

1. **RustFS could not be updated on its own.** A newer server binary only arrived when the whole launcher installer was rebuilt.
2. **Linux leaked into a Windows/macOS product.** Binary name mapping still mentioned Linux, but this repo does not ship Linux installers.
3. **The first cut of the manual update path was not finished.** Check/install were glued to the network and the Tauri app handle, so the extract → smoke-test → swap → record → launch sequence could not be regression-tested. A release without a build for the current platform (for example Intel macOS) still looked “updatable”.

## What changed

### Manual updates (launcher + RustFS)

- Startup runs a silent check. **Check for Updates** does the same check on demand.
- One check covers both:
  - **Launcher:** GitHub `latest.json` with minisign verification (existing Tauri updater path).
  - **RustFS:** `https://version.rustfs.com/latest.json`, then the platform zip from the upstream release, verified against that release’s `SHA256SUMS`, smoke-tested with `--version`, and installed into the app data directory.
- If `SHA256SUMS` has no archive for this platform, the UI explains that instead of offering **Update RustFS**.
- The Version card has **Update Launcher** and **Update RustFS**. If a launcher-managed RustFS is running, the user must confirm before it is stopped.
- A user-installed RustFS wins over the bundled copy. If a later launcher installer ships a newer RustFS, the bundled copy takes over again.
- `installed.json` is written atomically. A failed smoke test deletes the staged file and leaves the current binary in place.

### Windows and macOS only

Supported launch/update targets:

- macOS aarch64 and x86_64
- Windows x86_64 (ARM64 Windows still uses the x86_64 binary under emulation)

Linux is an explicit error: `RustFS Launcher supports Windows and macOS only`. `build.sh` refuses Linux as well. The UI shows the detected platform (for example `Windows (x86_64)` or `macOS (Apple Silicon)`).

### Other hardening

- Drop unused `tauri-plugin-shell` and `tauri-plugin-store`
- Missing tray icon logs a warning instead of panicking
- Default ports/credentials live in shared constants
- Failed update checks/installs are written to App Logs
- Basic a11y on toasts, log tabs, and the secret-key toggle; `html lang="en"`

## Tests

Offline coverage now walks the real install pipeline (no GitHub download):

- Parse `latest.json`, decide availability, and hide missing platform assets
- SHA-256 helpers and checksum mismatches
- Zip extraction (`rustfs`, nested `rustfs.exe`)
- Smoke-test success/failure and leftover cleanup
- Atomic commit of the binary + `installed.json`
- Launch and stop the committed stub
- Binary resolution prefers a newer installed file over the bundle
- Frontend helpers: display host, progress percent, idle/update copy

Commands run locally:

- `cargo fmt --all`
- `cargo clippy -p rustfs-launcher --all-targets -- -D warnings`
- `cargo test -p rustfs-launcher` (43 passed)
- `cargo test -p rustfs-launcher-ui` (3 passed)
- `cargo check -p rustfs-launcher-ui --target wasm32-unknown-unknown`

CI now runs both test crates. `cargo tauri dev` was not run here (no Windows/macOS GUI). The live download still needs a click-through on a desktop build.

## Docs

`docs/SELF_UPDATE.md`, `README.md`, and `README_ZH.md` describe both update paths and where the installed RustFS binary is stored.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d83d6dbb-48d6-4415-ae61-c2ea7e37423c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d83d6dbb-48d6-4415-ae61-c2ea7e37423c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

