### PR TITLE
fix: harden release packaging and runtime validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,13 +151,13 @@ jobs:
           # unrelated Homebrew installs fail before dependency resolution.
           brew untap aws/tap || true
           brew install trunk
-          cargo install tauri-cli
+          cargo install tauri-cli --version 2.11.4 --locked
 
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
           cargo install trunk --version 0.21.14 --locked
-          cargo install tauri-cli
+          cargo install tauri-cli --version 2.11.4 --locked
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,6 +147,9 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
+          # The hosted macOS image can contain an untrusted aws/tap that makes
+          # unrelated Homebrew installs fail before dependency resolution.
+          brew untap aws/tap || true
           brew install trunk
           cargo install tauri-cli
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,11 @@ on:
         description: "RustFS release tag to bundle. Defaults to the latest upstream release."
         required: false
         type: string
+      publish:
+        description: "Publish release assets and upload to R2. Manual runs default to a dry run."
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   # Build strategy check - determine build type and version
@@ -29,6 +34,7 @@ jobs:
       version: ${{ steps.check.outputs.version }}
       release_tag: ${{ steps.check.outputs.release_tag }}
       is_release: ${{ steps.check.outputs.is_release }}
+      should_publish: ${{ steps.check.outputs.should_publish }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -37,31 +43,38 @@ jobs:
 
       - name: Determine build strategy
         id: check
+        env:
+          MANUAL_PUBLISH: ${{ inputs.publish }}
         run: |
           should_build=true
           version=""
           release_tag=""
           is_release=false
+          should_publish=false
 
           if [[ "${{ github.event_name }}" == "release" ]]; then
             # Release event - get version from release tag
             release_tag="${{ github.event.release.tag_name }}"
             is_release=true
+            should_publish=true
             echo "📦 Release build detected: $release_tag"
           elif [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
             # Tag push - get version from tag
             release_tag="${GITHUB_REF#refs/tags/}"
             is_release=true
+            should_publish=true
             echo "🏷️ Tag build detected: $release_tag"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ -n "${{ github.event.inputs.tag }}" ]]; then
             # Manual trigger with tag input - treat as release
             release_tag="${{ github.event.inputs.tag }}"
             is_release=true
+            should_publish="${MANUAL_PUBLISH:-false}"
             echo "🏷️ Manual release build detected: $release_tag"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
             # Manual trigger against a tag ref
             release_tag="${GITHUB_REF#refs/tags/}"
             is_release=true
+            should_publish="${MANUAL_PUBLISH:-false}"
             echo "🏷️ Manual tag-ref build detected: $release_tag"
           else
             # Manual trigger without tag or other
@@ -73,15 +86,19 @@ jobs:
             version="$release_tag"
           fi
 
-          echo "should_build=$should_build" >> $GITHUB_OUTPUT
-          echo "version=$version" >> $GITHUB_OUTPUT
-          echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
-          echo "is_release=$is_release" >> $GITHUB_OUTPUT
+          {
+            echo "should_build=$should_build"
+            echo "version=$version"
+            echo "release_tag=$release_tag"
+            echo "is_release=$is_release"
+            echo "should_publish=$should_publish"
+          } >> "$GITHUB_OUTPUT"
 
           echo "📊 Build Summary:"
           echo "  - Should build: $should_build"
           echo "  - Version: $version"
           echo "  - Is release: $is_release"
+          echo "  - Publish: $should_publish"
 
   build:
     name: Build
@@ -224,16 +241,20 @@ jobs:
             echo "⚠️ No RustFS asset for $slug in $UPSTREAM_TAG"
             echo "available assets:"
             printf '%s\n' "$asset_list"
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "slug=$slug" >> "$GITHUB_OUTPUT"
+            {
+              echo "available=false"
+              echo "slug=$slug"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "✅ Using $selected"
-          echo "available=true" >> "$GITHUB_OUTPUT"
-          echo "slug=$slug" >> "$GITHUB_OUTPUT"
-          echo "asset=$selected" >> "$GITHUB_OUTPUT"
-          echo "dest=$dest" >> "$GITHUB_OUTPUT"
+          {
+            echo "available=true"
+            echo "slug=$slug"
+            echo "asset=$selected"
+            echo "dest=$dest"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Download RustFS binary (Unix)
         if: runner.os != 'Windows' && steps.rustfs_asset.outputs.available == 'true'
@@ -307,89 +328,52 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
-          mkdir -p artifacts
-
-          # 允许空 glob 返回空数组，避免 zip 在找不到文件时直接失败
-          shopt -s nullglob
+          ARTIFACT_DIR="$GITHUB_WORKSPACE/artifacts"
+          mkdir -p "$ARTIFACT_DIR"
 
           # Format: rustfs-launcher-{os}-{arch}-{version}
           ARTIFACT_PREFIX="rustfs-launcher-${{ matrix.os_name }}-${{ matrix.arch }}-${VERSION}"
+          LATEST_PREFIX="rustfs-launcher-${{ matrix.os_name }}-${{ matrix.arch }}-latest"
 
-          # 在 workspace 内搜索打包输出，不依赖固定路径
-          APP_DIR=$(find src-tauri target -path "*bundle/macos/*.app" -type d -print -quit 2>/dev/null || true)
-          UPDATER_FILE=$(find src-tauri target -path "*bundle/macos/*.app.tar.gz" -type f -print -quit 2>/dev/null || true)
-          DMG_FILE=$(find src-tauri target -path "*bundle/dmg/*.dmg" -type f -print -quit 2>/dev/null || true)
+          # 使用绝对路径，避免后续进入 app bundle 目录后破坏 updater/artifact 路径。
+          APP_DIR=$(find "$GITHUB_WORKSPACE/src-tauri" "$GITHUB_WORKSPACE/target" -path "*bundle/macos/*.app" -type d -print -quit 2>/dev/null || true)
+          DMG_FILE=$(find "$GITHUB_WORKSPACE/src-tauri" "$GITHUB_WORKSPACE/target" -path "*bundle/dmg/*.dmg" -type f -print -quit 2>/dev/null || true)
+          UPDATER_FILE=""
 
           echo "发现的 .app 目录：${APP_DIR:-无}"
-          echo "发现的 updater 文件：${UPDATER_FILE:-无}"
           echo "发现的 .dmg 文件：${DMG_FILE:-无}"
-          find src-tauri target -path "*bundle/*" -print 2>/dev/null | head -80 || true
+          find "$GITHUB_WORKSPACE/src-tauri" "$GITHUB_WORKSPACE/target" -path "*bundle/*" -print 2>/dev/null | head -80 || true
 
-          # `--bundles app` used to skip updater archives. If Tauri did not emit
-          # one, build it from the .app so latest.json can still be published.
-          if [ -z "$UPDATER_FILE" ] && [ -n "$APP_DIR" ]; then
+          if [ -z "$APP_DIR" ]; then
+            echo "❌ 未找到 .app 产物"
+            exit 1
+          fi
+
+          codesign --force --deep --sign - "$APP_DIR"
+          codesign --verify --deep --strict --verbose=4 "$APP_DIR"
+
+          # Rebuild the updater after signing the app so the archive contains
+          # the exact bundle that users will install.
+          if [ "$IS_RELEASE" = "true" ]; then
             APP_PARENT="$(dirname "$APP_DIR")"
             APP_NAME="$(basename "$APP_DIR")"
             UPDATER_FILE="${APP_PARENT}/${APP_NAME}.tar.gz"
             echo "ℹ️ Creating updater archive: $UPDATER_FILE"
             tar -C "$APP_PARENT" -czf "$UPDATER_FILE" "$APP_NAME"
-            if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
-              cargo tauri signer sign "$UPDATER_FILE"
-            fi
+            rm -f "${UPDATER_FILE}.sig"
+            cargo tauri signer sign "$UPDATER_FILE"
           fi
 
-          # Copy and rename DMG
-          if [ -n "$DMG_FILE" ]; then
-            cp "$DMG_FILE" "artifacts/${ARTIFACT_PREFIX}.dmg"
-            echo "✅ Created: ${ARTIFACT_PREFIX}.dmg"
-          fi
+          bash scripts/package-macos-artifacts.sh \
+            "$APP_DIR" \
+            "$UPDATER_FILE" \
+            "$DMG_FILE" \
+            "$ARTIFACT_DIR" \
+            "$ARTIFACT_PREFIX" \
+            "$LATEST_PREFIX" \
+            "$IS_RELEASE"
 
-          # Create and rename app.zip
-          if [ -n "$APP_DIR" ]; then
-            codesign --force --deep --sign - "$APP_DIR"
-            codesign --verify --deep --strict --verbose=4 "$APP_DIR"
-
-            APP_PARENT="$(dirname "$APP_DIR")"
-            APP_NAME="$(basename "$APP_DIR")"
-            cd "$APP_PARENT"
-            ditto -c -k --keepParent "$APP_NAME" "$GITHUB_WORKSPACE/artifacts/${ARTIFACT_PREFIX}.app.zip"
-            echo "✅ Created: ${ARTIFACT_PREFIX}.app.zip"
-          else
-            echo "❌ 未找到 .app 产物"
-            exit 1
-          fi
-
-          if [ "$IS_RELEASE" != "true" ]; then
-            echo "ℹ️ Development build: updater artifact is disabled"
-          elif [ -n "$UPDATER_FILE" ] && [ -f "${UPDATER_FILE}.sig" ]; then
-            UPDATER_NAME="${ARTIFACT_PREFIX}.app.tar.gz"
-            cp "$UPDATER_FILE" "artifacts/$UPDATER_NAME"
-            cp "${UPDATER_FILE}.sig" "artifacts/${UPDATER_NAME}.sig"
-            echo "✅ Created updater: $UPDATER_NAME"
-          else
-            echo "❌ 未找到 macOS updater 产物或签名"
-            exit 1
-          fi
-
-          # Create latest version files, preserving compound suffixes such as .app.tar.gz.sig
-          cd "$GITHUB_WORKSPACE/artifacts"
-          LATEST_PREFIX="rustfs-launcher-${{ matrix.os_name }}-${{ matrix.arch }}-latest"
-          VERSIONED_PREFIX="rustfs-launcher-${{ matrix.os_name }}-${{ matrix.arch }}-${VERSION}"
-          for file in "${VERSIONED_PREFIX}"*; do
-            if [ -f "$file" ]; then
-              suffix="${file#"$VERSIONED_PREFIX"}"
-              cp "$file" "${LATEST_PREFIX}${suffix}"
-              echo "✅ Created latest: ${LATEST_PREFIX}${suffix}"
-            fi
-          done
-
-          # 确保确实生成了产物
-          if [ $(ls -1 | wc -l) -eq 0 ]; then
-            echo "❌ 未生成任何 artifacts"
-            exit 1
-          fi
-
-          ls -la "$GITHUB_WORKSPACE/artifacts"
+          ls -la "$ARTIFACT_DIR"
 
       - name: Prepare and rename artifacts (Windows)
         if: runner.os == 'Windows' && steps.rustfs_asset.outputs.available == 'true'
@@ -490,7 +474,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload to Cloudflare R2
-        if: needs.build-check.outputs.is_release == 'true' && steps.rustfs_asset.outputs.available == 'true'
+        if: needs.build-check.outputs.should_publish == 'true' && steps.rustfs_asset.outputs.available == 'true'
         env:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -586,8 +570,8 @@ jobs:
 
           # Generate checksums
           cd release-assets
-          if ls *.dmg *.zip *.msi *.exe 2>/dev/null; then
-            sha256sum * > SHA256SUMS
+          if compgen -G '*.dmg' >/dev/null || compgen -G '*.zip' >/dev/null || compgen -G '*.msi' >/dev/null || compgen -G '*.exe' >/dev/null; then
+            sha256sum -- * > SHA256SUMS
             echo "✅ SHA256SUMS generated"
           else
             echo "⚠️ No files found for checksum generation"
@@ -652,8 +636,8 @@ jobs:
           jq . latest.json
 
       - name: Upload to GitHub Release
-        if: needs.build-check.outputs.is_release == 'true'
-        uses: softprops/action-gh-release@v1
+        if: needs.build-check.outputs.should_publish == 'true'
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.build-check.outputs.release_tag }}
           files: release-assets/*
@@ -661,3 +645,10 @@ jobs:
           prerelease: ${{ contains(needs.build-check.outputs.release_tag, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload release preview
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-assets-preview
+          path: release-assets/*
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
           cargo test -p rustfs-launcher --all-features --locked
           cargo test -p rustfs-launcher-ui --locked
           bash scripts/select-rustfs-asset.sh --self-test
+          bash scripts/test-package-macos-artifacts.sh
 
   test-native:
     name: Native tests (${{ matrix.os }})
@@ -94,6 +95,16 @@ jobs:
 
       - name: Compile tests
         run: cargo test -p rustfs-launcher --all-features --locked --no-run
+
+      - name: Run portable network tests
+        shell: bash
+        run: |
+          test_binary="target/portable-network-tests"
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            test_binary="${test_binary}.exe"
+          fi
+          rustc --edition=2021 --test src-tauri/src/network.rs -o "$test_binary"
+          "$test_binary"
 
       - name: Run tests
         # The Tauri-linked lib test harness fails to start on Windows GHA with

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -47,7 +47,7 @@ jobs:
             exit 1
           fi
           
-          echo "version=$UPSTREAM_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$UPSTREAM_VERSION" >> "$GITHUB_OUTPUT"
           echo "✅ 上游最新版本: $UPSTREAM_VERSION"
       
       - name: 获取当前仓库版本
@@ -55,7 +55,7 @@ jobs:
         run: |
           # 从最新的 git tag 获取当前版本
           CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
           echo "📦 当前版本: $CURRENT_VERSION"
       
       - name: 比较版本
@@ -72,16 +72,22 @@ jobs:
           
           if [ "$FORCE" = "true" ]; then
             echo "🔨 强制构建模式"
-            echo "has_new_version=true" >> $GITHUB_OUTPUT
-            echo "should_build=true" >> $GITHUB_OUTPUT
+            {
+              echo "has_new_version=true"
+              echo "should_build=true"
+            } >> "$GITHUB_OUTPUT"
           elif [ "$UPSTREAM_NORMALIZED" != "$CURRENT_NORMALIZED" ]; then
             echo "🆕 发现新版本: $UPSTREAM (当前: $CURRENT)"
-            echo "has_new_version=true" >> $GITHUB_OUTPUT
-            echo "should_build=true" >> $GITHUB_OUTPUT
+            {
+              echo "has_new_version=true"
+              echo "should_build=true"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "✅ 已是最新版本"
-            echo "has_new_version=false" >> $GITHUB_OUTPUT
-            echo "should_build=false" >> $GITHUB_OUTPUT
+            {
+              echo "has_new_version=false"
+              echo "should_build=false"
+            } >> "$GITHUB_OUTPUT"
           fi
       
       - name: 创建新版本标签

--- a/scripts/package-macos-artifacts.sh
+++ b/scripts/package-macos-artifacts.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 7 ]]; then
+  echo "usage: $0 <app-dir> <updater-file> <dmg-file> <artifact-dir> <artifact-prefix> <latest-prefix> <is-release>" >&2
+  exit 2
+fi
+
+app_dir="$1"
+updater_file="$2"
+dmg_file="$3"
+artifact_dir="$4"
+artifact_prefix="$5"
+latest_prefix="$6"
+is_release="$7"
+ditto_bin="${DITTO_BIN:-ditto}"
+
+if [[ ! -d "$app_dir" ]]; then
+  echo "macOS app bundle not found: $app_dir" >&2
+  exit 1
+fi
+
+mkdir -p "$artifact_dir"
+
+if [[ -n "$dmg_file" ]]; then
+  if [[ ! -f "$dmg_file" ]]; then
+    echo "macOS DMG not found: $dmg_file" >&2
+    exit 1
+  fi
+  cp "$dmg_file" "$artifact_dir/${artifact_prefix}.dmg"
+  echo "Created: ${artifact_prefix}.dmg"
+fi
+
+app_parent="$(dirname "$app_dir")"
+app_name="$(basename "$app_dir")"
+(
+  cd "$app_parent"
+  "$ditto_bin" -c -k --keepParent "$app_name" "$artifact_dir/${artifact_prefix}.app.zip"
+)
+echo "Created: ${artifact_prefix}.app.zip"
+
+if [[ "$is_release" == "true" ]]; then
+  if [[ -z "$updater_file" || ! -f "$updater_file" || ! -f "${updater_file}.sig" ]]; then
+    echo "macOS updater artifact or signature is missing: ${updater_file:-unset}" >&2
+    exit 1
+  fi
+
+  updater_name="${artifact_prefix}.app.tar.gz"
+  cp "$updater_file" "$artifact_dir/$updater_name"
+  cp "${updater_file}.sig" "$artifact_dir/${updater_name}.sig"
+  echo "Created updater: $updater_name"
+fi
+
+for file in "$artifact_dir/${artifact_prefix}"*; do
+  [[ -f "$file" ]] || continue
+  file_name="$(basename "$file")"
+  suffix="${file_name#"$artifact_prefix"}"
+  cp "$file" "$artifact_dir/${latest_prefix}${suffix}"
+  echo "Created latest: ${latest_prefix}${suffix}"
+done
+
+if ! find "$artifact_dir" -maxdepth 1 -type f -print -quit | grep -q .; then
+  echo "no macOS artifacts were generated" >&2
+  exit 1
+fi

--- a/scripts/test-package-macos-artifacts.sh
+++ b/scripts/test-package-macos-artifacts.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture_dir="$(mktemp -d "${TMPDIR:-/tmp}/launcher-macos-artifacts.XXXXXX")"
+trap 'rm -rf "$fixture_dir"' EXIT
+
+app_dir="$fixture_dir/target/release/bundle/macos/RustFS Launcher.app"
+updater_file="$fixture_dir/target/release/bundle/macos/RustFS Launcher.app.tar.gz"
+dmg_file="$fixture_dir/target/release/bundle/dmg/RustFS Launcher.dmg"
+artifact_dir="$fixture_dir/artifacts"
+stub_dir="$fixture_dir/bin"
+
+mkdir -p "$app_dir" "$(dirname "$dmg_file")" "$artifact_dir" "$stub_dir" "$fixture_dir/unrelated"
+printf 'app' > "$app_dir/Contents.txt"
+printf 'updater' > "$updater_file"
+printf 'signature' > "${updater_file}.sig"
+printf 'dmg' > "$dmg_file"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'output="${@: -1}"' \
+  'printf "zip" > "$output"' \
+  > "$stub_dir/ditto"
+chmod +x "$stub_dir/ditto"
+
+(
+  cd "$fixture_dir/unrelated"
+  DITTO_BIN="$stub_dir/ditto" \
+    bash "$repo_root/scripts/package-macos-artifacts.sh" \
+      "$app_dir" \
+      "$updater_file" \
+      "$dmg_file" \
+      "$artifact_dir" \
+      "rustfs-launcher-macos-aarch64-1.2.3-rc.1" \
+      "rustfs-launcher-macos-aarch64-latest" \
+      true
+)
+
+expected=(
+  rustfs-launcher-macos-aarch64-1.2.3-rc.1.app.tar.gz
+  rustfs-launcher-macos-aarch64-1.2.3-rc.1.app.tar.gz.sig
+  rustfs-launcher-macos-aarch64-1.2.3-rc.1.app.zip
+  rustfs-launcher-macos-aarch64-1.2.3-rc.1.dmg
+  rustfs-launcher-macos-aarch64-latest.app.tar.gz
+  rustfs-launcher-macos-aarch64-latest.app.tar.gz.sig
+  rustfs-launcher-macos-aarch64-latest.app.zip
+  rustfs-launcher-macos-aarch64-latest.dmg
+)
+
+for name in "${expected[@]}"; do
+  test -f "$artifact_dir/$name"
+done
+
+dev_artifact_dir="$fixture_dir/dev-artifacts"
+DITTO_BIN="$stub_dir/ditto" \
+  bash "$repo_root/scripts/package-macos-artifacts.sh" \
+    "$app_dir" \
+    "" \
+    "" \
+    "$dev_artifact_dir" \
+    "rustfs-launcher-macos-aarch64-dev" \
+    "rustfs-launcher-macos-aarch64-latest" \
+    false
+
+test -f "$dev_artifact_dir/rustfs-launcher-macos-aarch64-dev.app.zip"
+test -f "$dev_artifact_dir/rustfs-launcher-macos-aarch64-latest.app.zip"
+test ! -e "$dev_artifact_dir/rustfs-launcher-macos-aarch64-dev.app.tar.gz"
+
+unsigned_updater="$fixture_dir/unsigned.app.tar.gz"
+printf 'unsigned' > "$unsigned_updater"
+if DITTO_BIN="$stub_dir/ditto" \
+  bash "$repo_root/scripts/package-macos-artifacts.sh" \
+    "$app_dir" \
+    "$unsigned_updater" \
+    "" \
+    "$fixture_dir/unsigned-artifacts" \
+    "rustfs-launcher-macos-aarch64-unsigned" \
+    "rustfs-launcher-macos-aarch64-latest" \
+    true; then
+  echo "expected an unsigned updater to be rejected" >&2
+  exit 1
+fi
+
+echo "package-macos-artifacts test passed"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,13 +1,13 @@
 use crate::binaries;
 use crate::config::RustFsConfig;
 use crate::error::{Error, Result};
+use crate::network;
 use crate::platform;
 use crate::process;
 use crate::rustfs_update::{self, RustFsUpdateInfo};
 use crate::state::{self, add_app_log};
 use serde::Serialize;
 use std::io::Error as IoError;
-use std::net::ToSocketAddrs;
 use tauri::async_runtime;
 use tauri::{AppHandle, Emitter};
 use tauri_plugin_opener::OpenerExt;
@@ -56,18 +56,6 @@ enum UpdateProgress {
         content_length: Option<u64>,
     },
     Finished,
-}
-
-fn tcp_online(host: String, port: u16) -> bool {
-    let Ok(mut addrs) = (host.as_str(), port).to_socket_addrs() else {
-        return false;
-    };
-    let Some(socket_addr) = addrs.next() else {
-        return false;
-    };
-
-    std::net::TcpStream::connect_timeout(&socket_addr, std::time::Duration::from_millis(1000))
-        .is_ok()
 }
 
 #[tauri::command]
@@ -128,7 +116,7 @@ pub async fn get_rustfs_logs() -> Result<Vec<String>> {
 
 #[tauri::command]
 pub async fn check_tcp_connection(host: String, port: u16) -> Result<bool> {
-    let result = async_runtime::spawn_blocking(move || tcp_online(host, port))
+    let result = async_runtime::spawn_blocking(move || network::tcp_online(&host, port))
         .await
         .unwrap_or(false);
     Ok(result)
@@ -142,7 +130,7 @@ pub async fn is_rustfs_process_running() -> Result<bool> {
 #[tauri::command]
 pub async fn get_runtime_status(host: String, port: u16) -> Result<RuntimeStatus> {
     let managed_running = state::is_rustfs_process_running();
-    let service_online = async_runtime::spawn_blocking(move || tcp_online(host, port))
+    let service_online = async_runtime::spawn_blocking(move || network::tcp_online(&host, port))
         .await
         .unwrap_or(false);
 
@@ -303,12 +291,7 @@ pub async fn install_rustfs_update() -> Result<CommandResponse> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_http_url, tcp_online};
-
-    #[test]
-    fn tcp_online_rejects_invalid_hosts() {
-        assert!(!tcp_online("not a host".into(), 9));
-    }
+    use super::is_http_url;
 
     #[test]
     fn http_url_validation() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod binaries;
 mod commands;
 mod config;
 mod error;
+mod network;
 mod platform;
 mod process;
 mod rustfs_update;

--- a/src-tauri/src/network.rs
+++ b/src-tauri/src/network.rs
@@ -1,0 +1,96 @@
+use std::io;
+use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(1000);
+
+pub(crate) fn normalize_host(host: &str) -> &str {
+    let trimmed = host.trim();
+    trimmed
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(trimmed)
+}
+
+pub(crate) fn format_bind_address(host: &str, port: u16) -> String {
+    let host = normalize_host(host);
+    if host.contains(':') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
+fn resolve_socket_addrs(host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
+    (normalize_host(host), port)
+        .to_socket_addrs()
+        .map(Iterator::collect)
+}
+
+fn any_tcp_online(addrs: impl IntoIterator<Item = SocketAddr>, timeout: Duration) -> bool {
+    addrs
+        .into_iter()
+        .any(|addr| TcpStream::connect_timeout(&addr, timeout).is_ok())
+}
+
+pub(crate) fn tcp_online(host: &str, port: u16) -> bool {
+    resolve_socket_addrs(host, port)
+        .map(|addrs| any_tcp_online(addrs, CONNECT_TIMEOUT))
+        .unwrap_or(false)
+}
+
+pub(crate) fn is_port_available(host: &str, port: u16) -> bool {
+    resolve_socket_addrs(host, port)
+        .and_then(|addrs| TcpListener::bind(addrs.as_slice()))
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_and_formats_ipv6_hosts() {
+        assert_eq!(normalize_host("::1"), "::1");
+        assert_eq!(normalize_host("[::1]"), "::1");
+        assert_eq!(normalize_host(" 127.0.0.1 "), "127.0.0.1");
+        assert_eq!(format_bind_address("127.0.0.1", 9000), "127.0.0.1:9000");
+        assert_eq!(format_bind_address("::1", 9000), "[::1]:9000");
+        assert_eq!(format_bind_address("[::1]", 9001), "[::1]:9001");
+    }
+
+    #[test]
+    fn tcp_probe_tries_every_resolved_address() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let online = listener.local_addr().unwrap();
+        let closed_listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let offline = closed_listener.local_addr().unwrap();
+        drop(closed_listener);
+
+        assert!(any_tcp_online(
+            [offline, online],
+            Duration::from_millis(100)
+        ));
+    }
+
+    #[test]
+    fn bracketed_ipv6_uses_the_same_socket_as_unbracketed_ipv6() {
+        if !is_port_available("[::1]", 0) {
+            return;
+        }
+        let Ok(listener) = TcpListener::bind(("::1", 0)) else {
+            return;
+        };
+        let port = listener.local_addr().unwrap().port();
+
+        assert!(tcp_online("::1", port));
+        assert!(tcp_online("[::1]", port));
+        assert!(!is_port_available("[::1]", port));
+    }
+
+    #[test]
+    fn invalid_hosts_are_offline_and_unavailable() {
+        assert!(!tcp_online("[invalid", 9));
+        assert!(!is_port_available("[invalid", 9));
+    }
+}

--- a/src-tauri/src/process.rs
+++ b/src-tauri/src/process.rs
@@ -1,11 +1,11 @@
 use crate::binaries;
 use crate::config::RustFsConfig;
 use crate::error::{Error, Result};
+use crate::network::{format_bind_address, is_port_available};
 use crate::state::{
     acquire, add_app_log, add_rustfs_log, is_rustfs_process_running, set_rustfs_process, APP_HANDLE,
 };
 use std::io::{BufRead, BufReader};
-use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
@@ -13,14 +13,6 @@ use std::time::{Duration, Instant};
 use tauri::Manager;
 
 const EARLY_EXIT_WAIT: Duration = Duration::from_millis(400);
-
-pub(crate) fn format_bind_address(host: &str, port: u16) -> String {
-    if host.contains(':') && !host.starts_with('[') {
-        format!("[{host}]:{port}")
-    } else {
-        format!("{host}:{port}")
-    }
-}
 
 pub(crate) fn validate_data_path(path: &str) -> Result<&str> {
     let trimmed = path.trim();
@@ -45,12 +37,6 @@ pub(crate) fn resolve_data_path(path: &str) -> Result<PathBuf> {
     let candidate = PathBuf::from(trimmed);
     if !candidate.exists() {
         return Err(Error::DataPathNotExist(trimmed.to_string()));
-    }
-    if candidate.is_file() {
-        return candidate
-            .parent()
-            .map(Path::to_path_buf)
-            .ok_or_else(|| Error::DataPathNotDirectory(trimmed.to_string()));
     }
     if !candidate.is_dir() {
         return Err(Error::DataPathNotDirectory(trimmed.to_string()));
@@ -210,6 +196,12 @@ fn ensure_executable(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
     let metadata = std::fs::metadata(path)
         .map_err(|err| Error::Metadata(path.to_string_lossy().to_string(), err))?;
+    if !metadata.is_file() {
+        return Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Path is not a regular file",
+        )));
+    }
     let mut permissions = metadata.permissions();
     add_app_log(format!(
         "File permissions for {}: {:o}",
@@ -217,15 +209,13 @@ fn ensure_executable(path: &Path) -> Result<()> {
         permissions.mode()
     ));
 
-    if permissions.mode() & 0o111 == 0 {
+    if permissions.mode() & 0o100 == 0 {
         add_app_log(format!(
             "Binary is not executable, attempting to set +x: {}",
             path.display()
         ));
-        permissions.set_mode(permissions.mode() | 0o755);
-        if let Err(err) = std::fs::set_permissions(path, permissions) {
-            add_app_log(format!("WARNING: Failed to make binary executable: {err}"));
-        }
+        permissions.set_mode(permissions.mode() | 0o100);
+        std::fs::set_permissions(path, permissions).map_err(Error::Io)?;
     }
     Ok(())
 }
@@ -253,10 +243,6 @@ fn ensure_executable(path: &Path) -> Result<()> {
     }
 
     Ok(())
-}
-
-pub(crate) fn is_port_available(host: &str, port: u16) -> bool {
-    TcpListener::bind((host, port)).is_ok()
 }
 
 pub fn diagnose_binary() -> Result<String> {
@@ -293,10 +279,16 @@ pub(crate) struct LaunchPlan {
 
 pub(crate) fn build_launch_plan(config: &RustFsConfig, logs_dir: &Path) -> LaunchPlan {
     let mut args = Vec::new();
-    let mut env = vec![(
-        "RUSTFS_OBS_LOG_DIRECTORY".to_string(),
-        logs_dir.to_string_lossy().into_owned(),
-    )];
+    let mut env = vec![
+        (
+            "RUSTFS_OBS_LOG_DIRECTORY".to_string(),
+            logs_dir.to_string_lossy().into_owned(),
+        ),
+        (
+            "RUSTFS_CONSOLE_ENABLE".to_string(),
+            config.console_enable.to_string(),
+        ),
+    ];
 
     let address = format_bind_address(config.bind_host(), config.api_port());
     args.push("--address".to_string());
@@ -451,14 +443,8 @@ mod tests {
     use super::*;
     use crate::config::RustFsConfig;
     use std::fs;
+    use std::net::TcpListener;
     use std::path::PathBuf;
-
-    #[test]
-    fn wraps_ipv6_bind_addresses() {
-        assert_eq!(format_bind_address("127.0.0.1", 9000), "127.0.0.1:9000");
-        assert_eq!(format_bind_address("::1", 9000), "[::1]:9000");
-        assert_eq!(format_bind_address("[::1]", 9001), "[::1]:9001");
-    }
 
     #[test]
     fn rejects_flag_like_data_paths() {
@@ -471,6 +457,18 @@ mod tests {
             Err(Error::InvalidDataPath(_))
         ));
         assert!(validate_data_path("/tmp/rustfs-data").is_ok());
+    }
+
+    #[test]
+    fn rejects_a_file_as_the_data_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("not-a-directory");
+        fs::write(&file, b"data").unwrap();
+
+        assert!(matches!(
+            resolve_data_path(file.to_str().unwrap()),
+            Err(Error::DataPathNotDirectory(path)) if path == file.to_string_lossy()
+        ));
     }
 
     #[test]
@@ -594,6 +592,52 @@ mod tests {
             .iter()
             .any(|(key, value)| key == "RUSTFS_SECRET_KEY" && value == "sk-secret"));
         assert!(plan.args.contains(&"--console-enable".to_string()));
+        assert!(plan
+            .env
+            .iter()
+            .any(|(key, value)| key == "RUSTFS_CONSOLE_ENABLE" && value == "true"));
+    }
+
+    #[test]
+    fn disabled_console_is_explicit_in_the_environment() {
+        let config = RustFsConfig {
+            data_path: "/tmp/data".into(),
+            console_enable: false,
+            ..RustFsConfig::default()
+        };
+        let plan = build_launch_plan(&config, Path::new("/tmp/logs"));
+
+        assert!(!plan.args.iter().any(|arg| arg == "--console-enable"));
+        assert!(!plan.args.iter().any(|arg| arg == "--console-address"));
+        assert!(plan
+            .env
+            .iter()
+            .any(|(key, value)| key == "RUSTFS_CONSOLE_ENABLE" && value == "false"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn making_a_binary_executable_preserves_other_permission_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("rustfs");
+        fs::write(&binary, b"binary").unwrap();
+        fs::set_permissions(&binary, fs::Permissions::from_mode(0o640)).unwrap();
+
+        ensure_executable(&binary).unwrap();
+
+        let mode = fs::metadata(&binary).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o740);
+    }
+
+    #[test]
+    fn rejects_a_directory_as_the_binary_path() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            ensure_executable(dir.path()),
+            Err(Error::Io(error)) if error.kind() == std::io::ErrorKind::InvalidInput
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make macOS artifact paths independent of the current directory, rebuild the updater after app signing, and add a non-publishing manual release mode
- make release tooling reproducible on hosted runners by removing the stale untrusted Homebrew tap and installing a locked Tauri CLI
- reject file paths as storage directories, explicitly propagate the Console enabled state, normalize IPv6 hosts, try every resolved service address, and preserve Unix permission bits
- add macOS artifact fixture coverage and portable network tests that execute on Windows without loading the Tauri test harness

## Validation

- cargo test -p rustfs-launcher --all-features --locked
- cargo test -p rustfs-launcher-ui --locked
- cargo check -p rustfs-launcher-ui --target wasm32-unknown-unknown --locked
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- trunk build
- actionlint
- bash scripts/select-rustfs-asset.sh --self-test
- bash scripts/test-package-macos-artifacts.sh
- PR CI passed on Linux, macOS, and Windows
- non-publishing release canary passed: https://github.com/rustfs/launcher/actions/runs/33355667310